### PR TITLE
Feature/payment(#7)- 주문생성, 결제준비, 결제승인

### DIFF
--- a/src/main/java/com/ddang/usedauction/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/ddang/usedauction/config/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.ddang.usedauction.auction.exception.AuctionException;
 import com.ddang.usedauction.category.exception.CategoryException;
 import com.ddang.usedauction.image.exception.ImageException;
 import com.ddang.usedauction.member.exception.MemberException;
+import com.ddang.usedauction.payment.exception.PaymentException;
 import com.ddang.usedauction.point.exception.PointException;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -194,6 +195,16 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest()
             .body(GlobalApiResponse.toGlobalResponseFail(HttpStatus.BAD_REQUEST,
                 e.getPointErrorCode().getMessage()));
+    }
+
+    // 결제 관련 에러 핸들러 -> 400 에러
+    @ExceptionHandler(PaymentException.class)
+    public ResponseEntity<?> paymentExceptionHandler(PaymentException e) {
+        log.error("PaymentException", e);
+
+        return ResponseEntity.badRequest()
+            .body(GlobalApiResponse.toGlobalResponseFail(HttpStatus.BAD_REQUEST,
+                e.getPaymentErrorCode().getMessage()));
     }
 
 //    // 예상하지 못한 에러 핸들러 -> 500 에러

--- a/src/main/java/com/ddang/usedauction/config/RestTemplateConfig.java
+++ b/src/main/java/com/ddang/usedauction/config/RestTemplateConfig.java
@@ -1,0 +1,15 @@
+package com.ddang.usedauction.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    // restTemplate: rest 방식으로 api를 호출할 수 있는 클래스(http 요청을 하는 클래스)
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/ddang/usedauction/member/domain/Member.java
+++ b/src/main/java/com/ddang/usedauction/member/domain/Member.java
@@ -66,4 +66,9 @@ public class Member extends BaseTimeEntity {
             .createdAt(getCreatedAt())
             .build();
     }
+
+    // 포인트 충전
+    public void addPoint(int point) {
+        this.point += point;
+    }
 }

--- a/src/main/java/com/ddang/usedauction/order/controller/OrderController.java
+++ b/src/main/java/com/ddang/usedauction/order/controller/OrderController.java
@@ -7,8 +7,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,10 +29,9 @@ public class OrderController {
      */
     @PostMapping("/create")
     public ResponseEntity<GlobalApiResponse<?>> createOrder(
-//        @AuthenticationPrincipal UserDetails userDetails,
         @RequestBody @Valid OrderCreateDto.Request request
     ) {
-        OrderCreateDto.Response response = orderService.createOrder(request); // (userDetails, request);
+        OrderCreateDto.Response response = orderService.createOrder(request);
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(GlobalApiResponse.toGlobalResponse(HttpStatus.CREATED, response));

--- a/src/main/java/com/ddang/usedauction/order/controller/OrderController.java
+++ b/src/main/java/com/ddang/usedauction/order/controller/OrderController.java
@@ -1,0 +1,42 @@
+package com.ddang.usedauction.order.controller;
+
+import com.ddang.usedauction.config.GlobalApiResponse;
+import com.ddang.usedauction.order.dto.OrderCreateDto;
+import com.ddang.usedauction.order.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    /**
+     * 주문 생성
+     * 1. 포인트 충전 모달에서 구매할 포인트를 선택한다.
+     * 2. 다음 버튼을 누른다. -> 주문생성
+     *
+     * @param request 주문 요청 정보
+     * @return 성공 시 200 코드와 주문id, 실패 시 에러코드와 에러메시지
+     */
+    @PostMapping("/create")
+    public ResponseEntity<GlobalApiResponse<?>> createOrder(
+//        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody @Valid OrderCreateDto.Request request
+    ) {
+        OrderCreateDto.Response response = orderService.createOrder(request); // (userDetails, request);
+        return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(GlobalApiResponse.toGlobalResponse(HttpStatus.CREATED, response));
+    }
+}

--- a/src/main/java/com/ddang/usedauction/order/domain/Orders.java
+++ b/src/main/java/com/ddang/usedauction/order/domain/Orders.java
@@ -1,11 +1,15 @@
 package com.ddang.usedauction.order.domain;
 
 import com.ddang.usedauction.config.BaseTimeEntity;
+import com.ddang.usedauction.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,8 +29,9 @@ public class Orders extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id; // 주문 아이디
 
-    @Column(nullable = false)
-    private Long memberId; // 회원 아이디
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member; // 회원 아이디
 
     @Column(nullable = false)
     private String itemName; // 아이템명

--- a/src/main/java/com/ddang/usedauction/order/domain/Orders.java
+++ b/src/main/java/com/ddang/usedauction/order/domain/Orders.java
@@ -1,0 +1,40 @@
+package com.ddang.usedauction.order.domain;
+
+import com.ddang.usedauction.config.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.Min;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity(name = "orders")
+public class Orders extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 주문 아이디
+
+    @Column(nullable = false)
+    private Long memberId; // 회원 아이디
+
+    @Column(nullable = false)
+    private String itemName; // 아이템명
+
+    @Column(nullable = false)
+    @Min(value = 1, message = "아이템 가격은 1이상이어야 합니다.")
+    private int price; // 아이템 가격
+
+    @Setter
+    private String tid; // 결제 고유 번호 (결제준비요청 후 받는 응답에 존재. 결제승인처리 로직에 필요. 초기값은 null)
+}

--- a/src/main/java/com/ddang/usedauction/order/dto/OrderCreateDto.java
+++ b/src/main/java/com/ddang/usedauction/order/dto/OrderCreateDto.java
@@ -1,0 +1,43 @@
+package com.ddang.usedauction.order.dto;
+
+import com.ddang.usedauction.order.domain.Orders;
+import jakarta.validation.constraints.Min;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+public class OrderCreateDto {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class Request {
+
+        @Min(value = 1, message = "상품가격은 1이상이어야 합니다.")
+        private int price; // 상품가격
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class Response {
+
+        private Long orderId;
+        private Long memberId;
+
+        // order 엔티티를 response dto로 변환
+        public static Response fromEntity(Orders orders) {
+            return Response.builder()
+                .orderId(orders.getId())
+                .memberId(orders.getMemberId())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/ddang/usedauction/order/dto/OrderCreateDto.java
+++ b/src/main/java/com/ddang/usedauction/order/dto/OrderCreateDto.java
@@ -29,8 +29,8 @@ public class OrderCreateDto {
     @ToString
     public static class Response {
 
-        private Long orderId;
-        private Long memberId;
+        private Long orderId; // 주문 id
+        private Long memberId; // 회원 id
 
         // order 엔티티를 response dto로 변환
         public static Response fromEntity(Orders orders) {

--- a/src/main/java/com/ddang/usedauction/order/dto/OrderCreateDto.java
+++ b/src/main/java/com/ddang/usedauction/order/dto/OrderCreateDto.java
@@ -36,7 +36,7 @@ public class OrderCreateDto {
         public static Response fromEntity(Orders orders) {
             return Response.builder()
                 .orderId(orders.getId())
-                .memberId(orders.getMemberId())
+                .memberId(orders.getMember().getId())
                 .build();
         }
     }

--- a/src/main/java/com/ddang/usedauction/order/exception/OrderErrorCode.java
+++ b/src/main/java/com/ddang/usedauction/order/exception/OrderErrorCode.java
@@ -1,0 +1,16 @@
+package com.ddang.usedauction.order.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum OrderErrorCode {
+
+    NOT_FOUND_ORDER(HttpStatus.BAD_REQUEST.value(), "주문내역이 존재하지 않습니다.")
+    ;
+
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/com/ddang/usedauction/order/exception/OrderException.java
+++ b/src/main/java/com/ddang/usedauction/order/exception/OrderException.java
@@ -1,0 +1,14 @@
+package com.ddang.usedauction.order.exception;
+
+import lombok.Getter;
+
+@Getter
+public class OrderException extends RuntimeException {
+
+    private final OrderErrorCode orderErrorCode;
+
+    public OrderException(OrderErrorCode orderErrorCode) {
+        super(orderErrorCode.getMessage());
+        this.orderErrorCode = orderErrorCode;
+    }
+}

--- a/src/main/java/com/ddang/usedauction/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddang/usedauction/order/repository/OrderRepository.java
@@ -1,12 +1,10 @@
 package com.ddang.usedauction.order.repository;
 
 import com.ddang.usedauction.order.domain.Orders;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderRepository extends JpaRepository<Orders, Long> {
 
-    Optional<Orders> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/ddang/usedauction/order/repository/OrderRepository.java
+++ b/src/main/java/com/ddang/usedauction/order/repository/OrderRepository.java
@@ -1,0 +1,12 @@
+package com.ddang.usedauction.order.repository;
+
+import com.ddang.usedauction.order.domain.Orders;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Orders, Long> {
+
+    Optional<Orders> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/ddang/usedauction/order/service/OrderService.java
+++ b/src/main/java/com/ddang/usedauction/order/service/OrderService.java
@@ -1,37 +1,24 @@
 package com.ddang.usedauction.order.service;
 
-import static com.ddang.usedauction.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
-
 import com.ddang.usedauction.member.domain.Member;
-import com.ddang.usedauction.member.exception.MemberException;
-import com.ddang.usedauction.member.repository.MemberRepository;
 import com.ddang.usedauction.order.domain.Orders;
 import com.ddang.usedauction.order.dto.OrderCreateDto;
 import com.ddang.usedauction.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class OrderService {
 
-//    private final MemberRepository memberRepository;
     private final OrderRepository orderRepository;
 
     // 주문 생성
     public OrderCreateDto.Response createOrder(OrderCreateDto.Request request) {
 
-        // 아래 코드는 테스트 용이성을 위해 주석처리. 회원기능 구현 완료시 수정 예정
-        // (UserDetails userDetails, OrderCreateDto.Request request) {
-
-        // String email = userDetails.getUsername();
-        // Member member = memberRepository.findByEmail(email)
-        //    .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
-
         Member member = Member.builder()
             .id(1L)
-            .build();
+            .build(); // TODO 토큰을 받아 처리하는 것으로 수정
 
         String itemName = request.getPrice() + " 포인트";
 

--- a/src/main/java/com/ddang/usedauction/order/service/OrderService.java
+++ b/src/main/java/com/ddang/usedauction/order/service/OrderService.java
@@ -36,7 +36,7 @@ public class OrderService {
         String itemName = request.getPrice() + " 포인트";
 
         Orders order = Orders.builder()
-            .memberId(member.getId())
+            .member(member)
             .itemName(itemName)
             .price(request.getPrice())
             .build();

--- a/src/main/java/com/ddang/usedauction/order/service/OrderService.java
+++ b/src/main/java/com/ddang/usedauction/order/service/OrderService.java
@@ -1,0 +1,48 @@
+package com.ddang.usedauction.order.service;
+
+import static com.ddang.usedauction.member.exception.MemberErrorCode.NOT_FOUND_MEMBER;
+
+import com.ddang.usedauction.member.domain.Member;
+import com.ddang.usedauction.member.exception.MemberException;
+import com.ddang.usedauction.member.repository.MemberRepository;
+import com.ddang.usedauction.order.domain.Orders;
+import com.ddang.usedauction.order.dto.OrderCreateDto;
+import com.ddang.usedauction.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+//    private final MemberRepository memberRepository;
+    private final OrderRepository orderRepository;
+
+    // 주문 생성
+    public OrderCreateDto.Response createOrder(OrderCreateDto.Request request) {
+
+        // 아래 코드는 테스트 용이성을 위해 주석처리. 회원기능 구현 완료시 수정 예정
+        // (UserDetails userDetails, OrderCreateDto.Request request) {
+
+        // String email = userDetails.getUsername();
+        // Member member = memberRepository.findByEmail(email)
+        //    .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+
+        Member member = Member.builder()
+            .id(1L)
+            .build();
+
+        String itemName = request.getPrice() + " 포인트";
+
+        Orders order = Orders.builder()
+            .memberId(member.getId())
+            .itemName(itemName)
+            .price(request.getPrice())
+            .build();
+
+        orderRepository.save(order);
+
+        return OrderCreateDto.Response.fromEntity(order);
+    }
+}

--- a/src/main/java/com/ddang/usedauction/payment/controller/PaymentController.java
+++ b/src/main/java/com/ddang/usedauction/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package com.ddang.usedauction.payment.controller;
 
 import com.ddang.usedauction.config.GlobalApiResponse;
+import com.ddang.usedauction.payment.dto.PaymentApproveDto;
 import com.ddang.usedauction.payment.dto.PaymentInfoDto;
 import com.ddang.usedauction.payment.dto.PaymentReadyDto;
 import com.ddang.usedauction.payment.service.PaymentService;
@@ -14,6 +15,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -27,7 +29,9 @@ public class PaymentController {
     /**
      * 결제 준비
      * 1. 사용자가 카카오페이 버튼을 누른다.(/api/members/payment/ready)
-     * 2. ready()에서 받은 요청을 통해 결제 준비에 필요한 정보로 가공하고 이를 카카오서버로 요청한다.
+     * 2. ready()에서 받은 요청을 통해 결제 준비에 필요한 정보로 가공하고 이를 카카오서버로 보낸다.
+     * 3. 응답으로 결제 승인 요청에 필요한 정보(tid 등)를 받는다.
+     * 4. 결제 승인 요청에 필요한 tid를 db에 저장한다. -> redis로 변경 예정
      *
      * @param request 주문 상세 정보
      * @return 성공 시 200 코드와 결제 승인에 필요한 정보(tid, redirect_url 등), 실패 시 에러코드와 에러메시지
@@ -38,6 +42,45 @@ public class PaymentController {
         @RequestBody @Valid PaymentInfoDto.Request request
     ) {
         PaymentReadyDto.Response response = paymentService.ready(request); // (userDetails, request);
+        log.info("response: {}", response);
+
         return ResponseEntity.ok(GlobalApiResponse.toGlobalResponse(HttpStatus.OK, response));
     }
+
+    /**
+     * 결제 승인
+     * 1. 카카오페이 포인트, 카드 등 결제 수단을 선택하고 결제하기 버튼을 누른다.
+     * 2. faceID 등으로 결제 인증을 완료하면 pg_token과 tid로 결제 승인 요청을 한다.
+     * 3. pg_token은 1번에서 결제 버튼을 눌러 approval_url로 리다이렉트 될 때 approval_url에 포함된 쿼리스트링으로 받는다.
+     *    (http://localhost:8080/payment/success?partner_order_id=1&pg_token=13123123123123123)
+     * 4. tid는 이전에 결제 준비 단계에서 db에 저장된 값을 가져와 사용한다.
+     * 5. tid를 가져오기 위해 approval_url에 쿼리스트링으로 partner_order_id을 넣었는데 이 값을 통해 가져올 수 있다.
+     * 6. 승인이 완료되면 사용자의 포인트를 충전하고 포인트 충전내역을 생성해 저장한다.
+     *
+     * @param partnerOrderId 주문 id
+     * @param pgToken 결제 준비 완료후 결제 인증(faceID 등 본인인증)을 통과하면 카카오쪽에서 pgToken을 응답으로 줌
+     * @return 성공 시 200 코드와 결제 정보(아이템명, 수량 등), 실패 시 에러코드와 에러메시지
+     */
+    @PostMapping("/approve")
+    public ResponseEntity<?> paymentApprove(
+        @RequestParam("partnerOrderId") String partnerOrderId,
+        @RequestParam("pgToken") String pgToken
+    ) {
+        PaymentApproveDto.Response response = paymentService.approve(partnerOrderId, pgToken);
+        log.info("response: {}", response);
+
+        return ResponseEntity.ok(GlobalApiResponse.toGlobalResponse(HttpStatus.OK, response));
+    }
+
+//    // 결제 취소
+//    @GetMapping("/cancel")
+//    public void cancel() {
+//        throw new PaymentException(PAYMENT_CANCEL);
+//    }
+//
+//    // 결제 실패
+//    @GetMapping("/fail")
+//    public void fail() {
+//        throw new PaymentException(PAYMENT_FAIL);
+//    }
 }

--- a/src/main/java/com/ddang/usedauction/payment/controller/PaymentController.java
+++ b/src/main/java/com/ddang/usedauction/payment/controller/PaymentController.java
@@ -1,0 +1,43 @@
+package com.ddang.usedauction.payment.controller;
+
+import com.ddang.usedauction.config.GlobalApiResponse;
+import com.ddang.usedauction.payment.dto.PaymentInfoDto;
+import com.ddang.usedauction.payment.dto.PaymentReadyDto;
+import com.ddang.usedauction.payment.service.PaymentService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/payment")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    /**
+     * 결제 준비
+     * 1. 사용자가 카카오페이 버튼을 누른다.(/api/members/payment/ready)
+     * 2. ready()에서 받은 요청을 통해 결제 준비에 필요한 정보로 가공하고 이를 카카오서버로 요청한다.
+     *
+     * @param request 주문 상세 정보
+     * @return 성공 시 200 코드와 결제 승인에 필요한 정보(tid, redirect_url 등), 실패 시 에러코드와 에러메시지
+     */
+    @PostMapping("/ready")
+    public ResponseEntity<?> paymentReady(
+//        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody @Valid PaymentInfoDto.Request request
+    ) {
+        PaymentReadyDto.Response response = paymentService.ready(request); // (userDetails, request);
+        return ResponseEntity.ok(GlobalApiResponse.toGlobalResponse(HttpStatus.OK, response));
+    }
+}

--- a/src/main/java/com/ddang/usedauction/payment/controller/PaymentController.java
+++ b/src/main/java/com/ddang/usedauction/payment/controller/PaymentController.java
@@ -10,8 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,10 +36,9 @@ public class PaymentController {
      */
     @PostMapping("/ready")
     public ResponseEntity<?> paymentReady(
-//        @AuthenticationPrincipal UserDetails userDetails,
         @RequestBody @Valid PaymentInfoDto.Request request
     ) {
-        PaymentReadyDto.Response response = paymentService.ready(request); // (userDetails, request);
+        PaymentReadyDto.Response response = paymentService.ready(request);
         log.info("response: {}", response);
 
         return ResponseEntity.ok(GlobalApiResponse.toGlobalResponse(HttpStatus.OK, response));
@@ -71,16 +68,4 @@ public class PaymentController {
 
         return ResponseEntity.ok(GlobalApiResponse.toGlobalResponse(HttpStatus.OK, response));
     }
-
-//    // 결제 취소
-//    @GetMapping("/cancel")
-//    public void cancel() {
-//        throw new PaymentException(PAYMENT_CANCEL);
-//    }
-//
-//    // 결제 실패
-//    @GetMapping("/fail")
-//    public void fail() {
-//        throw new PaymentException(PAYMENT_FAIL);
-//    }
 }

--- a/src/main/java/com/ddang/usedauction/payment/dto/Amount.java
+++ b/src/main/java/com/ddang/usedauction/payment/dto/Amount.java
@@ -1,0 +1,21 @@
+package com.ddang.usedauction.payment.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Amount {
+
+    private Integer total; // 전체 결제 금액
+    private Integer tax_free; // 비과세 금액
+
+//    private Integer vat; // 부가세 금액
+//    private Integer point; // 사용한 카카오페이 포인트 금액
+//    private Integer discount; // 할인 금액
+}

--- a/src/main/java/com/ddang/usedauction/payment/dto/PaymentApproveDto.java
+++ b/src/main/java/com/ddang/usedauction/payment/dto/PaymentApproveDto.java
@@ -1,0 +1,59 @@
+package com.ddang.usedauction.payment.dto;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+public class PaymentApproveDto {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class Request {
+
+        private String cid; // 가맹점코드 (테스트용이라 "TC0ONETIME"로 고정)
+        private String tid; // 결제 고유번호, 결제 준비 API 응답에 포함
+        private String partnerOrderId; // 주문 id
+        private String partnerUserId; // 회원 id
+        private String pgToken; // 결제승인 요청을 인증하는 토큰. 사용자 결제 수단 선택 완료 시, approval_url로 redirection 해줄 때 pg_token을 query string으로 전달
+
+        // map으로 변환
+        public Map<String, String> toMap() {
+            Map<String, String> map = new HashMap<>();
+            map.put("cid", this.cid);
+            map.put("tid", this.tid);
+            map.put("partner_order_id", this.partnerOrderId);
+            map.put("partner_user_id", this.partnerUserId);
+            map.put("pg_token", this.pgToken);
+            return map;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class Response {
+
+        private String aid; // 요청 고유 번호 - 승인/취소가 구분된 결제번호
+        private String tid; // 결제 고유 번호 - 승인/취소가 동일한 결제번호
+        private String cid; // 가맹점 코드
+        private String partner_order_id; // 주문 id
+        private String partner_user_id; // 회원 id
+        private String payment_method_type; // 결제 수단, CARD 또는 MONEY 중 하나
+        private Amount amount; // 결제 금액 정보
+        private String item_name; // 상품명
+        private Integer quantity; // 상품 수량
+        private LocalDateTime created_at; // 결제 준비 요청 시각
+        private LocalDateTime approved_at; // 결제 승인 시각
+    }
+}

--- a/src/main/java/com/ddang/usedauction/payment/dto/PaymentInfoDto.java
+++ b/src/main/java/com/ddang/usedauction/payment/dto/PaymentInfoDto.java
@@ -1,0 +1,31 @@
+package com.ddang.usedauction.payment.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+public class PaymentInfoDto {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class Request {
+
+        @NotNull(message = "주문 id는 null 일 수 없습니다.")
+        private Long orderId; // 주문 id
+
+        @NotNull(message = "회원 id는 null 일 수 없습니다.")
+        private Long memberId; // 회원 id
+
+        @NotNull(message = "상품가격이 비어있습니다. 상품가격이 필요합니다.")
+        @Min(value = 1, message = "상품가격은 1 이상이어야 합니다.")
+        private int price; // 상품가격
+    }
+}

--- a/src/main/java/com/ddang/usedauction/payment/dto/PaymentReadyDto.java
+++ b/src/main/java/com/ddang/usedauction/payment/dto/PaymentReadyDto.java
@@ -1,0 +1,59 @@
+package com.ddang.usedauction.payment.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+public class PaymentReadyDto {
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class Request {
+        private String cid;
+        private String partnerOrderId;
+        private String partnerUserId;
+        private String itemName;
+        private String quantity;
+        private String totalAmount;
+        private String taxFreeAmount;
+        private String approvalUrl;
+        private String cancelUrl;
+        private String failUrl;
+
+        //  map으로 변환
+        public Map<String, String> toMap() {
+            Map<String, String> map = new HashMap<>();
+            map.put("cid", this.cid);
+            map.put("partner_order_id", this.partnerOrderId);
+            map.put("partner_user_id", this.partnerUserId);
+            map.put("item_name", this.itemName);
+            map.put("quantity", "1");
+            map.put("total_amount", this.totalAmount);
+            map.put("tax_free_amount", "0");
+            map.put("approval_url", "http://localhost:8080/payment/success?partner_order_id=" + this.partnerOrderId);
+            map.put("cancel_url", "http://localhost:8080/payment/cancel");
+            map.put("fail_url", "http://localhost:8080/payment/fail");
+            return map;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class Response {
+
+        private String tid; // 결제 고유 번호
+        private String next_redirect_pc_url; // 요청한 클라이언트가 PC 웹일 경우 카카오톡으로 결제 요청 메시지(TMS)를 보내기 위한 사용자 정보 입력 화면 Redirect URL
+        private String created_at; // 결제준비를 요청한 시간
+    }
+}

--- a/src/main/java/com/ddang/usedauction/payment/dto/PaymentReadyDto.java
+++ b/src/main/java/com/ddang/usedauction/payment/dto/PaymentReadyDto.java
@@ -17,16 +17,16 @@ public class PaymentReadyDto {
     @Builder
     @ToString
     public static class Request {
-        private String cid;
-        private String partnerOrderId;
-        private String partnerUserId;
-        private String itemName;
-        private String quantity;
-        private String totalAmount;
-        private String taxFreeAmount;
-        private String approvalUrl;
-        private String cancelUrl;
-        private String failUrl;
+        private String cid; // 가맹점코드 (테스트용이라 "TC0ONETIME"로 고정)
+        private String partnerOrderId; // 주문id
+        private String partnerUserId; // 유저id
+        private String itemName; // 상품명(100포인트, 200포인트)
+        private String quantity; // 상품 수량
+        private String totalAmount; // 상품 가격
+        private String taxFreeAmount; // 상품 비과세 금액 (0으로 고정)
+        private String approvalUrl; // 결제 성공 시 redirect url
+        private String cancelUrl; // 결제 취소 시 redirect url
+        private String failUrl; // 결제 실패 시 redirect url
 
         //  map으로 변환
         public Map<String, String> toMap() {

--- a/src/main/java/com/ddang/usedauction/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/ddang/usedauction/payment/exception/PaymentErrorCode.java
@@ -1,0 +1,18 @@
+package com.ddang.usedauction.payment.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentErrorCode {
+
+    INVALID_USER(HttpStatus.BAD_REQUEST, "동일한 유저가 아닙니다."),
+    PAYMENT_CANCEL(HttpStatus.BAD_REQUEST, "결제가 취소되었습니다."),
+    PAYMENT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "결제에 실패하였습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/ddang/usedauction/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/ddang/usedauction/payment/exception/PaymentErrorCode.java
@@ -8,11 +8,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PaymentErrorCode {
 
-    INVALID_USER(HttpStatus.BAD_REQUEST, "동일한 유저가 아닙니다."),
-    PAYMENT_CANCEL(HttpStatus.BAD_REQUEST, "결제가 취소되었습니다."),
-    PAYMENT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "결제에 실패하였습니다.")
+    INVALID_USER(HttpStatus.BAD_REQUEST.value(), "동일한 유저가 아닙니다."),
+    PAYMENT_CANCEL(HttpStatus.BAD_REQUEST.value(), "결제가 취소되었습니다."),
+    PAYMENT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "결제에 실패하였습니다.")
     ;
 
-    private final HttpStatus httpStatus;
+    private final int status;
     private final String message;
 }

--- a/src/main/java/com/ddang/usedauction/payment/exception/PaymentErrorCode.java
+++ b/src/main/java/com/ddang/usedauction/payment/exception/PaymentErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum PaymentErrorCode {
 
     INVALID_USER(HttpStatus.BAD_REQUEST.value(), "동일한 유저가 아닙니다."),
+    NOT_EQUAL_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST.value(), "요청 금액과 저장된 금액이 일치하지 않습니다."),
     PAYMENT_CANCEL(HttpStatus.BAD_REQUEST.value(), "결제가 취소되었습니다."),
     PAYMENT_FAIL(HttpStatus.INTERNAL_SERVER_ERROR.value(), "결제에 실패하였습니다.")
     ;

--- a/src/main/java/com/ddang/usedauction/payment/exception/PaymentException.java
+++ b/src/main/java/com/ddang/usedauction/payment/exception/PaymentException.java
@@ -1,0 +1,14 @@
+package com.ddang.usedauction.payment.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PaymentException extends RuntimeException {
+
+    private final PaymentErrorCode paymentErrorCode;
+
+    public PaymentException(PaymentErrorCode paymentErrorCode) {
+        super(paymentErrorCode.getMessage());
+        this.paymentErrorCode = paymentErrorCode;
+    }
+}

--- a/src/main/java/com/ddang/usedauction/payment/service/PaymentService.java
+++ b/src/main/java/com/ddang/usedauction/payment/service/PaymentService.java
@@ -143,7 +143,7 @@ public class PaymentService {
 
         // 요청으로 받은 값들을 String으로 변환
         String tidStr = String.valueOf(order.getTid());
-        String memberIdStr = String.valueOf(order.getMemberId());
+        String memberIdStr = String.valueOf(order.getMember().getId());
 
         // 카카오로 보낼 결제 승인 요청에 필요한 정보들 생성
         // header 설정

--- a/src/main/java/com/ddang/usedauction/payment/service/PaymentService.java
+++ b/src/main/java/com/ddang/usedauction/payment/service/PaymentService.java
@@ -1,11 +1,26 @@
 package com.ddang.usedauction.payment.service;
 
+import static com.ddang.usedauction.order.exception.OrderErrorCode.NOT_FOUND_ORDER;
 import static com.ddang.usedauction.payment.exception.PaymentErrorCode.INVALID_USER;
+import static com.ddang.usedauction.payment.exception.PaymentErrorCode.NOT_EQUAL_PAYMENT_AMOUNT;
+import static com.ddang.usedauction.payment.exception.PaymentErrorCode.PAYMENT_FAIL;
+import static com.ddang.usedauction.point.type.PointType.CHARGE;
 
 import com.ddang.usedauction.member.domain.Member;
+import com.ddang.usedauction.member.exception.MemberErrorCode;
+import com.ddang.usedauction.member.exception.MemberException;
+import com.ddang.usedauction.member.repository.MemberRepository;
+import com.ddang.usedauction.order.domain.Orders;
+import com.ddang.usedauction.order.exception.OrderErrorCode;
+import com.ddang.usedauction.order.exception.OrderException;
+import com.ddang.usedauction.order.repository.OrderRepository;
+import com.ddang.usedauction.payment.dto.PaymentApproveDto;
 import com.ddang.usedauction.payment.dto.PaymentInfoDto;
 import com.ddang.usedauction.payment.dto.PaymentReadyDto;
 import com.ddang.usedauction.payment.exception.PaymentException;
+import com.ddang.usedauction.point.domain.PointHistory;
+import com.ddang.usedauction.point.repository.PointRepository;
+import com.ddang.usedauction.point.type.PointType;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,11 +29,13 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PaymentService {
 
     @Value("${payment.secret-key}")
@@ -31,8 +48,10 @@ public class PaymentService {
     private static final String HEADER_AUTHORIZATION = "Authorization";
     private static final String HEADER_CONTENT_TYPE = "Content-Type";
 
-//    private final MemberRepository memberRepository;
     private final RestTemplate restTemplate;
+    private final OrderRepository orderRepository;
+    private final MemberRepository memberRepository;
+    private final PointRepository pointRepository;
 
     // 결제 준비
     public PaymentReadyDto.Response ready (PaymentInfoDto.Request request) {
@@ -47,9 +66,17 @@ public class PaymentService {
             .id(1L)
             .build();
 
-        // 로그인한 유저와 요청으로 받은 유저의 id가 같은지 검증
-        if(!member.getId().equals(request.getMemberId())) {
+        Orders order = orderRepository.findByMemberId(member.getId())
+            .orElseThrow(() -> new OrderException(NOT_FOUND_ORDER));
+
+        // 로그인한 유저와 요청으로 받은 유저의 id가 동일한지 비교
+        if (!member.getId().equals(request.getMemberId())) {
             throw new PaymentException(INVALID_USER);
+        }
+
+        // db에 저장된 금액과 입력받은 금액이 동일한지 비교
+        if (order.getPrice() != request.getPrice()) {
+            throw new PaymentException(NOT_EQUAL_PAYMENT_AMOUNT);
         }
 
         // 요청으로 받은 값들을 String으로 변환
@@ -58,6 +85,7 @@ public class PaymentService {
         String itemNameStr = request.getPrice() + " 포인트"; // 포인트아이템을 db에 저장하지 않으므로 포인트값으로 아이템명을 생성함
         String priceStr = String.valueOf(request.getPrice());
 
+        // 카카오로 보낼 결제 준비 요청에 필요한 정보들 생성
         // header 설정
         HttpHeaders headers = new HttpHeaders();
         headers.set(HEADER_AUTHORIZATION, "SECRET_KEY " + SECRET_KEY);
@@ -90,6 +118,10 @@ public class PaymentService {
         );
 
         log.info("response: {}", response);
+
+        // order 테이블에 tid 저장
+        order.setTid(response.getTid());
+        orderRepository.save(order);
 
         return response;
     }

--- a/src/main/java/com/ddang/usedauction/payment/service/PaymentService.java
+++ b/src/main/java/com/ddang/usedauction/payment/service/PaymentService.java
@@ -1,0 +1,96 @@
+package com.ddang.usedauction.payment.service;
+
+import static com.ddang.usedauction.payment.exception.PaymentErrorCode.INVALID_USER;
+
+import com.ddang.usedauction.member.domain.Member;
+import com.ddang.usedauction.payment.dto.PaymentInfoDto;
+import com.ddang.usedauction.payment.dto.PaymentReadyDto;
+import com.ddang.usedauction.payment.exception.PaymentException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    @Value("${payment.secret-key}")
+    private String SECRET_KEY;
+
+    @Value("${payment.ready}")
+    private String READY_URL;
+
+    static final String CID = "TC0ONETIME";
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String HEADER_CONTENT_TYPE = "Content-Type";
+
+//    private final MemberRepository memberRepository;
+    private final RestTemplate restTemplate;
+
+    // 결제 준비
+    public PaymentReadyDto.Response ready (PaymentInfoDto.Request request) {
+//         아래 코드는 테스트 용이성을 위해 주석처리. 회원기능 구현 완료시 수정 예정
+//         (UserDetails userDetails, PaymentReadyDto.Request request) {
+
+//        String email = userDetails.getUsername();
+//        Member member = memberRepository.findByEmail(email)
+//            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+
+        Member member = Member.builder()
+            .id(1L)
+            .build();
+
+        // 로그인한 유저와 요청으로 받은 유저의 id가 같은지 검증
+        if(!member.getId().equals(request.getMemberId())) {
+            throw new PaymentException(INVALID_USER);
+        }
+
+        // 요청으로 받은 값들을 String으로 변환
+        String orderIdStr = String.valueOf(request.getOrderId());
+        String memberIdStr = String.valueOf(member.getId());
+        String itemNameStr = request.getPrice() + " 포인트"; // 포인트아이템을 db에 저장하지 않으므로 포인트값으로 아이템명을 생성함
+        String priceStr = String.valueOf(request.getPrice());
+
+        // header 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HEADER_AUTHORIZATION, "SECRET_KEY " + SECRET_KEY);
+        headers.set(HEADER_CONTENT_TYPE, "application/json");
+
+        // body 설정
+        PaymentReadyDto.Request paymentRequest = PaymentReadyDto.Request.builder()
+            .cid(CID)
+            .partnerOrderId(String.valueOf(orderIdStr))
+            .partnerUserId(String.valueOf(memberIdStr))
+            .itemName(itemNameStr)
+            .quantity("1")
+            .totalAmount(priceStr)
+            .taxFreeAmount("0")
+            .approvalUrl("http://localhost:8080/payment/success?partner_order_id=" + orderIdStr)
+            .cancelUrl("http://localhost:8080/payment/cancel")
+            .failUrl("http://localhost:8080/payment/fail")
+            .build();
+
+        // paymentRequest를 map으로 변환
+        Map<String, String> map = paymentRequest.toMap();
+
+        // header, body 하나로 합치기
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(map, headers);
+
+        // restTemplate.postForObject(요청 보낼 url, 헤더+바디, 응답을 매핑할 dto)
+        // postForObject: post 요청을 보내고 응답받은 json을 java 객체로 변환
+        PaymentReadyDto.Response response = restTemplate.postForObject(
+            READY_URL, requestEntity, PaymentReadyDto.Response.class
+        );
+
+        log.info("response: {}", response);
+
+        return response;
+    }
+}

--- a/src/main/java/com/ddang/usedauction/payment/service/PaymentService.java
+++ b/src/main/java/com/ddang/usedauction/payment/service/PaymentService.java
@@ -56,15 +56,9 @@ public class PaymentService {
 
     // 결제 준비
     public PaymentReadyDto.Response ready (PaymentInfoDto.Request request) {
-//         아래 코드는 테스트 용이성을 위해 주석처리. 회원기능 구현 완료시 수정 예정
-//         (UserDetails userDetails, PaymentReadyDto.Request request) {
-
-//        String email = userDetails.getUsername();
-//        Member member = memberRepository.findByEmail(email)
-//            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
         Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER)); // TODO 토큰을 받아 처리하는 것으로 수정
 
         Orders order = orderRepository.findById(request.getOrderId())
             .orElseThrow(() -> new OrderException(NOT_FOUND_ORDER));
@@ -127,15 +121,9 @@ public class PaymentService {
 
     // 결제 승인
     public PaymentApproveDto.Response approve(String partnerOrderId, String pgToken) {
-//         아래 코드는 테스트 용이성을 위해 주석처리. 회원기능 구현 완료시 수정 예정
-//         (UserDetails userDetails, PaymentReadyDto.Request request) {
-
-//        String email = userDetails.getUsername();
-//        Member member = memberRepository.findByEmail(email)
-//            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
 
         Member member = memberRepository.findById(1L)
-            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER));
+            .orElseThrow(() -> new MemberException(NOT_FOUND_MEMBER)); // TODO 토큰을 받아 처리하는 것으로 수정
 
         Long orderId = Long.valueOf(partnerOrderId);
         Orders order = orderRepository.findById(orderId)

--- a/src/main/resources/application-build.yml
+++ b/src/main/resources/application-build.yml
@@ -65,3 +65,9 @@ logging:
           descriptor:
             sql: trace
   config: classpath:logback-spring.xml
+
+# 카카오페이 secretKey
+payment:
+  secret-key: ${PAY_SECRET_KEY}
+  ready: https://open-api.kakaopay.com/online/v1/payment/ready
+  approve: https://open-api.kakaopay.com/online/v1/payment/approve

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,7 +18,7 @@ spring:
         format_sql: true
         highlight_sql: true
         default_batch_fetch_size: 100
-    defer-datasource-initialization: true
+    defer-datasource-initialization: true # data.sql을 사용하기 위해 데이터소스 초기화를 지연시키는 설정
 
   datasource:
     username: ${DB_USER_NAME} # 환경 변수

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -18,6 +18,7 @@ spring:
         format_sql: true
         highlight_sql: true
         default_batch_fetch_size: 100
+    defer-datasource-initialization: true
 
   datasource:
     username: ${DB_USER_NAME} # 환경 변수
@@ -75,3 +76,4 @@ logging:
 payment:
   secret-key: ${PAY_SECRET_KEY}
   ready: https://open-api.kakaopay.com/online/v1/payment/ready
+  approve: https://open-api.kakaopay.com/online/v1/payment/approve

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -70,3 +70,8 @@ logging:
           descriptor:
             sql: trace
   config: classpath:logback-spring.xml
+
+# 카카오페이 secretKey
+payment:
+  secret-key: ${PAY_SECRET_KEY}
+  ready: https://open-api.kakaopay.com/online/v1/payment/ready

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,14 @@
+INSERT INTO member (id, member_id, pass_word, email, site_alarm, point, social, social_provider_id, deleted_at, created_at, updated_at)
+VALUES (
+           1,
+           'loginId',
+           '1231231312',
+           'test@example.com',
+           false,
+           100,
+           'socialLogin',
+           'socialProviderId',
+           NULL,
+           CURRENT_TIMESTAMP,
+           CURRENT_TIMESTAMP
+       );


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 주문 생성 api를 추가했습니다.
- 결제 준비 api를 추가했습니다.
  - 로그인한 유저와 요청으로 받은 유저의 id에 대한 유효성 검사를 진행합니다.
  - db에 저장된 금액과 입력받은 금액이 동일한지에 대한 유효성 검사를 진행합니다.
  - 주문정보를 받아 가공하여 결제 준비 요청을 보내고 응답을 받습니다.
  - 응답으로 받은 tid를 db에 저장해서 결제 승인 단계에서 사용할 수 있도록 했습니다.
- 결제 승인 api를 추가했습니다.
  - 주문 id와 pg_token을 받아 결제 승인 요청을 보내고 응답을 받습니다.
  - 결제 승인이 완료되면 회원의 포인트가 충전되고, 포인트 내역에는 충전 내역이 추가됩니다.

**TO-BE**
- tid를 서버db가 아닌 redis에 저장할지 고민중입니다.
- 주문 취소, 실패했을 경우에 대한 기능을 구현해야합니다.

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트