### PR TITLE
Feature/instant purchase with auto confirm(#9) - 즉시 구매 일주일 이후 자동 구매 확정

### DIFF
--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -51,6 +51,7 @@ public class AuctionService {
     private final TransactionRepository transactionRepository;
     private final PointRepository pointRepository;
     private final ImageService imageService;
+    private final AuctionRedisService auctionRedisService;
 
     /**
      * 경매글 단건 조회
@@ -316,6 +317,10 @@ public class AuctionService {
             .point(buyer.getPoint() - auction.getInstantPrice()) // 즉시 구매 가격만큼 포인트 차감
             .build();
         memberRepository.save(buyer);
+
+        auctionRedisService.createAutoConfirm(auctionId, memberId, auction.getInstantPrice(),
+            auction.getSeller()
+                .getId()); // 일주일 후 자동 구매 확정 되도록 설정
 
         // todo: 경매 종료 알림(판매자 및 낙찰자) 및 채팅방 생성
     }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 즉시 구매 이후 일주일 지난 뒤 자동으로 구매 확정이 진행됩니다.

**TO-BE**

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [ ] API 테스트

### API 테스트

- 경매의 즉시구매가 = 4000

<details>
  <summary>초기 회원 데이터</summary>
  
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/3cace6a0-ad2b-47d2-8ec3-1017eb3ceeae">

</details>

<details>
  <summary>즉시 구매 진행</summary>
  
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/26ba4027-11ae-4215-932e-6510f2fe9e46">

</details>

<details>
  <summary>자동 구매 확정 (편의상 7초후로 설정)</summary>
  
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/62d68926-91dc-460d-aead-8300a0527438">

</details>

<details>
  <summary>자동 구매 확정 후 포인트 히스토리 및 거래 내역</summary>
  
<img width="790" alt="image" src="https://github.com/user-attachments/assets/9506f310-b272-41fc-8995-8ba15bae705a">
<img width="687" alt="image" src="https://github.com/user-attachments/assets/3fbe6c10-c5f7-4f2e-9040-71ede1201831">

</details>