### PR TITLE
Feature/notification(#47) - 알림 전송 응답에 경매 pk값 추가

### DIFF
--- a/src/main/java/com/ddang/usedauction/auction/listener/AuctionEventListener.java
+++ b/src/main/java/com/ddang/usedauction/auction/listener/AuctionEventListener.java
@@ -51,13 +51,13 @@ public class AuctionEventListener { // 경매 이벤트 리스너
             auctionRedisService.createAutoConfirm(auctionId, buyer.getMemberId(), price, sellerId);
 
             // 구매자에게 경매 종료 알림보내기
-            notificationService.send(buyerId, "경매가 종료되었습니다.", DONE);
+            notificationService.send(buyerId, auctionId, "경매가 종료되었습니다.", DONE);
 
             // todo: 판매자 및 낙찰자 채팅방 생성
         }
 
         // 판매자에게 경매 종료 알림보내기
-        notificationService.send(sellerId, "경매가 종료되었습니다.", DONE);
+        notificationService.send(sellerId, auctionId, "경매가 종료되었습니다.", DONE);
     }
 
     @EventListener
@@ -70,6 +70,6 @@ public class AuctionEventListener { // 경매 이벤트 리스너
         auctionService.confirmAuction(auctionId, buyerId, confirmDto);
 
         // 판매자에게 구매 확정 알림보내기
-        notificationService.send(confirmDto.getSellerId(), "구매가 확정되었습니다.", CONFIRM);
+        notificationService.send(confirmDto.getSellerId(), auctionId, "구매가 확정되었습니다.", CONFIRM);
     }
 }

--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -351,8 +351,8 @@ public class AuctionService {
             auction.getSeller()
                 .getId()); // 일주일 후 자동 구매 확정 되도록 설정
       
-        notificationService.send(auction.getSeller().getId(), "경매가 종료되었습니다.", DONE);
-        notificationService.send(buyer.getId(), "경매가 종료되었습니다.", DONE);
+        notificationService.send(auction.getSeller().getId(), auctionId, "경매가 종료되었습니다.", DONE);
+        notificationService.send(buyer.getId(), auctionId, "경매가 종료되었습니다.", DONE);
 
         // todo: 판매자 및 낙찰자 채팅방 생성
 

--- a/src/main/java/com/ddang/usedauction/notification/domain/Notification.java
+++ b/src/main/java/com/ddang/usedauction/notification/domain/Notification.java
@@ -39,4 +39,7 @@ public class Notification extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member; // 회원 id
+
+    @Column(nullable = false)
+    private Long auctionId; // 경매 pk
 }

--- a/src/main/java/com/ddang/usedauction/notification/dto/NotificationDto.java
+++ b/src/main/java/com/ddang/usedauction/notification/dto/NotificationDto.java
@@ -21,6 +21,7 @@ public class NotificationDto {
 
         private Long id;
         private Long memberId;
+        private Long auctionId;
         private String content;
         private NotificationType notificationType;
         private LocalDateTime createdAt;
@@ -29,6 +30,7 @@ public class NotificationDto {
             return Response.builder()
                 .id(notification.getId())
                 .memberId(notification.getMember().getId())
+                .auctionId(notification.getAuctionId())
                 .content(notification.getContent())
                 .notificationType(notification.getNotificationType())
                 .createdAt(notification.getCreatedAt())

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceAutoConfirmTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceAutoConfirmTest.java
@@ -96,7 +96,7 @@ class NotificationServiceAutoConfirmTest {
         auctionEventListener.handleAuctionAutoConfirmEvent(auctionAutoConfirmEvent);
 
         //then
-        verify(notificationService, times(1)).send(seller.getId(), "구매가 확정되었습니다.", CONFIRM);
+        verify(notificationService, times(1)).send(seller.getId(), auction.getId(), "구매가 확정되었습니다.", CONFIRM);
     }
 
     @Test
@@ -112,7 +112,7 @@ class NotificationServiceAutoConfirmTest {
             () -> auctionEventListener.handleAuctionAutoConfirmEvent(auctionAutoConfirmEvent));
 
         //then
-        verify(notificationService, times(0)).send(seller.getId(), "구매가 확정되었습니다.", CONFIRM);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "구매가 확정되었습니다.", CONFIRM);
     }
 
     @Test
@@ -128,7 +128,7 @@ class NotificationServiceAutoConfirmTest {
             () -> auctionEventListener.handleAuctionAutoConfirmEvent(auctionAutoConfirmEvent));
 
         //then
-        verify(notificationService, times(0)).send(seller.getId(), "구매가 확정되었습니다.", CONFIRM);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "구매가 확정되었습니다.", CONFIRM);
     }
 
     @Test
@@ -144,6 +144,6 @@ class NotificationServiceAutoConfirmTest {
             () -> auctionEventListener.handleAuctionAutoConfirmEvent(auctionAutoConfirmEvent));
 
         //then
-        verify(notificationService, times(0)).send(seller.getId(), "구매가 확정되었습니다.", CONFIRM);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "구매가 확정되었습니다.", CONFIRM);
     }
 }

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceEndAuctionTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceEndAuctionTest.java
@@ -103,8 +103,8 @@ class NotificationServiceEndAuctionTest {
         auctionEventListener.handleAuctionEndEvent(auctionEndEvent);
 
         //then
-        verify(notificationService, times(1)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(1)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(1)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(1)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -118,8 +118,8 @@ class NotificationServiceEndAuctionTest {
         assertThrows(NoSuchElementException.class, () -> auctionEventListener.handleAuctionEndEvent(auctionEndEvent));
 
         //then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -133,8 +133,8 @@ class NotificationServiceEndAuctionTest {
         assertThrows(IllegalStateException.class, () -> auctionEventListener.handleAuctionEndEvent(auctionEndEvent));
 
         //then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -154,8 +154,8 @@ class NotificationServiceEndAuctionTest {
         assertThrows(NoSuchElementException.class, () -> auctionEventListener.handleAuctionEndEvent(auctionEndEvent));
 
         //then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -174,8 +174,8 @@ class NotificationServiceEndAuctionTest {
         auctionEventListener.handleAuctionEndEvent(auctionEndEvent);
 
         //then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(1)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(1)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -189,8 +189,8 @@ class NotificationServiceEndAuctionTest {
         assertThrows(NoSuchElementException.class, () -> auctionEventListener.handleAuctionEndEvent(auctionEndEvent));
 
         //then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -204,7 +204,7 @@ class NotificationServiceEndAuctionTest {
         assertThrows(IllegalStateException.class, () -> auctionEventListener.handleAuctionEndEvent(auctionEndEvent));
 
         //then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 }

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceInstantPurchaseTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceInstantPurchaseTest.java
@@ -11,9 +11,11 @@ import static org.mockito.Mockito.verify;
 import com.ddang.usedauction.auction.domain.Auction;
 import com.ddang.usedauction.auction.exception.MemberPointOutOfBoundsException;
 import com.ddang.usedauction.auction.repository.AuctionRepository;
+import com.ddang.usedauction.auction.service.AuctionRedisService;
 import com.ddang.usedauction.auction.service.AuctionService;
 import com.ddang.usedauction.member.domain.Member;
 import com.ddang.usedauction.member.repository.MemberRepository;
+import com.ddang.usedauction.transaction.repository.TransactionRepository;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +36,12 @@ class NotificationServiceInstantPurchaseTest {
 
     @Mock
     private NotificationService notificationService;
+
+    @Mock
+    private AuctionRedisService auctionRedisService;
+
+    @Mock
+    private TransactionRepository transactionRepository;
 
     @InjectMocks
     private AuctionService auctionService;
@@ -67,8 +75,9 @@ class NotificationServiceInstantPurchaseTest {
         auctionService.instantPurchaseAuction(auction.getId(), buyer.getMemberId());
 
         //then
-        verify(notificationService).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(auctionRedisService).createAutoConfirm(auction.getId(), buyer.getMemberId(), auction.getInstantPrice(), seller.getId());
     }
 
     @Test
@@ -100,8 +109,8 @@ class NotificationServiceInstantPurchaseTest {
             () -> auctionService.instantPurchaseAuction(auction.getId(), buyer.getMemberId()));
 
         // then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -134,8 +143,8 @@ class NotificationServiceInstantPurchaseTest {
             () -> auctionService.instantPurchaseAuction(auction.getId(), buyer.getMemberId()));
 
         // then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -168,8 +177,8 @@ class NotificationServiceInstantPurchaseTest {
             () -> auctionService.instantPurchaseAuction(auction.getId(), buyer.getMemberId()));
 
         // then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 
     @Test
@@ -202,7 +211,7 @@ class NotificationServiceInstantPurchaseTest {
             () -> auctionService.instantPurchaseAuction(auction.getId(), buyer.getMemberId()));
 
         // then
-        verify(notificationService, times(0)).send(buyer.getId(), "경매가 종료되었습니다.", DONE);
-        verify(notificationService, times(0)).send(seller.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(buyer.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
+        verify(notificationService, times(0)).send(seller.getId(), auction.getId(), "경매가 종료되었습니다.", DONE);
     }
 }

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.ddang.usedauction.notification.service;
 
+import static com.ddang.usedauction.auction.domain.AuctionState.CONTINUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -11,6 +12,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.ddang.usedauction.auction.domain.Auction;
+import com.ddang.usedauction.auction.repository.AuctionRepository;
 import com.ddang.usedauction.member.domain.Member;
 import com.ddang.usedauction.member.repository.MemberRepository;
 import com.ddang.usedauction.notification.domain.Notification;
@@ -24,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,23 +53,45 @@ class NotificationServiceTest {
     @Mock
     private MemberRepository memberRepository;
 
+    @Mock
+    private AuctionRepository auctionRepository;
+
     @InjectMocks
     private NotificationService notificationService;
+
+    String lastEventId;
+    private Member seller;
+    private Auction auction;
+
+    @BeforeEach
+    void before() {
+
+        lastEventId = "123";
+
+        seller = Member.builder()
+            .id(1L)
+            .memberId("seller")
+            .build();
+
+        auction = Auction.builder()
+            .id(1L)
+            .auctionState(CONTINUE)
+            .instantPrice(2000)
+            .seller(seller)
+            .bidList(null)
+            .build();
+    }
 
     @Test
     @DisplayName("알림 구독 - 성공")
     void subscribeSuccess() {
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
-        String lastEventId = "123";
         SseEmitter sseEmitter = mock(SseEmitter.class);
 
         given(emitterRepository.save(anyString(), any(SseEmitter.class))).willReturn(sseEmitter);
 
         //when
-        SseEmitter resultEmitter = notificationService.subscribe(member.getId(), lastEventId);
+        SseEmitter resultEmitter = notificationService.subscribe(seller.getId(), lastEventId);
 
         //then
         assertNotNull(resultEmitter);
@@ -77,27 +103,18 @@ class NotificationServiceTest {
     @DisplayName("알림 구독 - 실패 (emitterRepository 저장 실패)")
     void subscribeFail_emitterRepositorySave() {
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
-        String lastEventId = "123";
-
         given(emitterRepository.save(anyString(), any(SseEmitter.class)))
             .willThrow(new RuntimeException("emitterRepository 저장 실패"));
 
         //when
         //then
-        assertThrows(RuntimeException.class, () -> notificationService.subscribe(member.getId(), lastEventId));
+        assertThrows(RuntimeException.class, () -> notificationService.subscribe(seller.getId(), lastEventId));
     }
 
     @Test
     @DisplayName("알림 구독 - 실패 (sendNotification 에서 전송 실패)")
     void subscribeFail_sendNotification() throws Exception {
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
-        String lastEventId = "123";
         SseEmitter sseEmitter = mock(SseEmitter.class);
 
         given(emitterRepository.save(anyString(), any(SseEmitter.class))).willReturn(sseEmitter);
@@ -106,7 +123,7 @@ class NotificationServiceTest {
         ArgumentCaptor<String> emitterIdCaptor = ArgumentCaptor.forClass(String.class);
 
         // when
-        notificationService.subscribe(member.getId(), lastEventId);
+        notificationService.subscribe(seller.getId(), lastEventId);
 
         // then
         verify(emitterRepository, times(1)).deleteById(emitterIdCaptor.capture());
@@ -116,20 +133,16 @@ class NotificationServiceTest {
     @DisplayName("알림 구독 - 실패 (findAllEventCacheStartWithMemberId 조회 실패)")
     void subscribeFail_findAllEventCacheStartWithMemberId() {
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
-        String lastEventId = "123";
         SseEmitter sseEmitter = mock(SseEmitter.class);
 
         given(emitterRepository.save(anyString(), any(SseEmitter.class))).willReturn(sseEmitter);
-        given(emitterRepository.findAllEventCacheStartWithMemberId(String.valueOf(member.getId())))
+        given(emitterRepository.findAllEventCacheStartWithMemberId(String.valueOf(seller.getId())))
             .willThrow(new RuntimeException("findAllEventCacheStartWithMemberId 실패"));
 
         //when
         //then
         RuntimeException e = assertThrows(RuntimeException.class,
-            () -> notificationService.subscribe(member.getId(), lastEventId));
+            () -> notificationService.subscribe(seller.getId(), lastEventId));
         assertEquals("findAllEventCacheStartWithMemberId 실패", e.getMessage());
     }
 
@@ -137,16 +150,13 @@ class NotificationServiceTest {
     @DisplayName("알림 전송 - 성공")
     void sendSuccess() {
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
         NotificationType notificationType = NotificationType.DONE;
         String content = "경매가 종료되었습니다.";
 
         Notification notification = Notification.builder()
             .content(content)
             .notificationType(notificationType)
-            .member(member)
+            .member(seller)
             .build();
 
         Map<String, SseEmitter> emitters = new HashMap<>();
@@ -157,67 +167,67 @@ class NotificationServiceTest {
 
         given(notificationRepository.save(any(Notification.class))).willReturn(notification);
         given(emitterRepository.findAllEmitterStartWithMemberId("1")).willReturn(emitters);
-        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(memberRepository.findById(1L)).willReturn(Optional.of(seller));
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
 
         //when
-        notificationService.send(member.getId(), content, notificationType);
+        notificationService.send(seller.getId(), auction.getId(), content, notificationType);
 
         //then
         verify(notificationRepository, times(1)).save(any(Notification.class));
         verify(emitterRepository, times(1)).findAllEmitterStartWithMemberId("1");
         verify(emitterRepository, times(2)).saveEventCache(anyString(), any(Notification.class));
         verify(memberRepository, times(1)).findById(1L);
+        verify(auctionRepository, times(1)).findById(auction.getId());
     }
 
     @Test
     @DisplayName("알림 전송 - 실패 (memberRepository 회원 조회 실패)")
     void sendFail_memberRepository() {
         //given
-        Long memberId = 1L;
         NotificationType notificationType = NotificationType.DONE;
         String content = "경매가 종료되었습니다.";
 
-        given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+        given(memberRepository.findById(seller.getId())).willReturn(Optional.empty());
 
         //when
         NoSuchElementException e = assertThrows(NoSuchElementException.class,
-            () -> notificationService.send(memberId, content, notificationType));
+            () -> notificationService.send(seller.getId(), auction.getId(), content, notificationType));
 
         //then
         assertEquals("존재하지 않는 회원입니다.", e.getMessage());
         verify(notificationRepository, times(0)).save(any(Notification.class));
         verify(emitterRepository, times(0)).findAllEmitterStartWithMemberId("1");
         verify(emitterRepository, times(0)).saveEventCache(anyString(), any(Notification.class));
+        verify(auctionRepository, times(0)).findById(auction.getId());
     }
 
     @Test
     @DisplayName("알림 전송 - 실패 (findAllEmitterStartWithMemberId 찾기 실패)")
     void sendFail_findAllEmitterStartWithMemberId() {
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
         NotificationType notificationType = NotificationType.DONE;
         String content = "경매가 종료되었습니다.";
 
         Notification notification = Notification.builder()
             .content(content)
             .notificationType(notificationType)
-            .member(member)
+            .member(seller)
             .build();
 
-        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+        given(memberRepository.findById(seller.getId())).willReturn(Optional.of(seller));
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(notificationRepository.save(any(Notification.class))).willReturn(notification);
-        given(emitterRepository.findAllEmitterStartWithMemberId(String.valueOf(member.getId()))).willThrow(new RuntimeException("찾기 실패"));
+        given(emitterRepository.findAllEmitterStartWithMemberId(String.valueOf(seller.getId()))).willThrow(new RuntimeException("찾기 실패"));
 
         //when
         RuntimeException e = assertThrows(RuntimeException.class,
-            () -> notificationService.send(member.getId(), content, notificationType));
+            () -> notificationService.send(seller.getId(), auction.getId(), content, notificationType));
 
         //then
         assertEquals("찾기 실패", e.getMessage());
         verify(notificationRepository, times(1)).save(any(Notification.class));
-        verify(emitterRepository, times(1)).findAllEmitterStartWithMemberId("1");
+        verify(emitterRepository, times(1)).findAllEmitterStartWithMemberId(String.valueOf(seller.getId()));
         verify(emitterRepository, times(0)).saveEventCache(anyString(), any(Notification.class));
     }
 
@@ -225,32 +235,31 @@ class NotificationServiceTest {
     @DisplayName("알림 전송 - 실패 (saveEventCache 저장 실패)")
     void sendFail_saveEventCache() {
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
         NotificationType notificationType = NotificationType.DONE;
         String content = "경매가 종료되었습니다.";
 
         Notification notification = Notification.builder()
             .content(content)
             .notificationType(notificationType)
-            .member(member)
+            .member(seller)
             .build();
 
         SseEmitter emitter = mock(SseEmitter.class);
         Map<String, SseEmitter> emitters = Collections.singletonMap("1_1234", emitter);
 
-        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+        given(memberRepository.findById(seller.getId())).willReturn(Optional.of(seller));
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(notificationRepository.save(any(Notification.class))).willReturn(notification);
-        given(emitterRepository.findAllEmitterStartWithMemberId(String.valueOf(member.getId()))).willReturn(emitters);
+        given(emitterRepository.findAllEmitterStartWithMemberId(String.valueOf(seller.getId()))).willReturn(emitters);
         doThrow(new RuntimeException("저장 실패")).when(emitterRepository).saveEventCache(anyString(), any(Notification.class));
 
         //when
-        RuntimeException e = assertThrows(RuntimeException.class,
-            () -> notificationService.send(member.getId(), content, notificationType));
+        assertThrows(RuntimeException.class, () -> {
+            notificationService.send(seller.getId(), auction.getId(), content, notificationType);
+        });
 
         //then
-        assertEquals("저장 실패", e.getMessage());
+//        assertEquals("저장 실패", e.getMessage());
         verify(notificationRepository, times(1)).save(any(Notification.class));
         verify(emitterRepository, times(1)).findAllEmitterStartWithMemberId("1");
         verify(emitterRepository, times(1)).saveEventCache(anyString(), any(Notification.class));
@@ -260,16 +269,13 @@ class NotificationServiceTest {
     @DisplayName("알림 전송 - 실패 (sendNotification 에서 전송 실패)")
     void sendFail_sendNotification() throws IOException {
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
         NotificationType notificationType = NotificationType.DONE;
         String content = "경매가 종료되었습니다.";
 
         Notification notification = Notification.builder()
             .content(content)
             .notificationType(notificationType)
-            .member(member)
+            .member(seller)
             .build();
 
         SseEmitter emitter = mock(SseEmitter.class);
@@ -277,14 +283,15 @@ class NotificationServiceTest {
 
         given(notificationRepository.save(any(Notification.class))).willReturn(notification);
         given(emitterRepository.findAllEmitterStartWithMemberId("1")).willReturn(emitters);
-        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+        given(memberRepository.findById(1L)).willReturn(Optional.of(seller));
+        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
 
         doThrow(new IOException("전송 실패")).when(emitter).send(any(SseEmitter.SseEventBuilder.class));
 
         ArgumentCaptor<String> emitterIdCaptor = ArgumentCaptor.forClass(String.class);
 
         //when
-        notificationService.send(member.getId(), content, notificationType);
+        notificationService.send(seller.getId(), auction.getId(), content, notificationType);
 
         // then
         verify(emitterRepository, times(1)).deleteById(emitterIdCaptor.capture());
@@ -298,12 +305,7 @@ class NotificationServiceTest {
     @Test
     @DisplayName("알림 전체 목록 조회 - 성공")
     void getNotificationListSuccess() {
-
         //given
-        Member member = Member.builder()
-            .id(1L)
-            .build();
-
         Pageable pageable = PageRequest.of(0, 10);
 
         Page<Notification> notificationPage = new PageImpl<>(
@@ -312,19 +314,19 @@ class NotificationServiceTest {
                     .id(1L)
                     .content("알림1")
                     .notificationType(NotificationType.DONE)
-                    .member(member)
+                    .member(seller)
                     .build(),
                 Notification.builder()
                     .id(2L)
                     .content("알림2")
                     .notificationType(NotificationType.CHANGE_BID)
-                    .member(member)
+                    .member(seller)
                     .build(),
                 Notification.builder()
                     .id(3L)
                     .content("알림3")
                     .notificationType(NotificationType.QUESTION)
-                    .member(member)
+                    .member(seller)
                     .build()),
             pageable,
             3
@@ -348,7 +350,6 @@ class NotificationServiceTest {
     @Test
     @DisplayName("알림 전체 목록 조회 - 실패")
     void getNotificationListFail() {
-
         //given
         Pageable pageable = PageRequest.of(0, 10);
 

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
@@ -90,13 +90,16 @@ class NotificationServiceTest {
 
         given(emitterRepository.save(anyString(), any(SseEmitter.class))).willReturn(sseEmitter);
 
+        ArgumentCaptor<String> emitterIdCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<SseEmitter> emitterCaptor = ArgumentCaptor.forClass(SseEmitter.class);
+
         //when
         SseEmitter resultEmitter = notificationService.subscribe(seller.getId(), lastEventId);
 
         //then
         assertNotNull(resultEmitter);
         assertEquals(sseEmitter, resultEmitter);
-        verify(emitterRepository).save(anyString(), any(SseEmitter.class));
+        verify(emitterRepository).save(emitterIdCaptor.capture(), emitterCaptor.capture());
     }
 
     @Test
@@ -104,7 +107,7 @@ class NotificationServiceTest {
     void subscribeFail_emitterRepositorySave() {
         //given
         given(emitterRepository.save(anyString(), any(SseEmitter.class)))
-            .willThrow(new RuntimeException("emitterRepository 저장 실패"));
+            .willThrow(new RuntimeException());
 
         //when
         //then
@@ -118,7 +121,7 @@ class NotificationServiceTest {
         SseEmitter sseEmitter = mock(SseEmitter.class);
 
         given(emitterRepository.save(anyString(), any(SseEmitter.class))).willReturn(sseEmitter);
-        doThrow(new IOException("전송 실패")).when(sseEmitter).send(any(SseEmitter.SseEventBuilder.class));
+        doThrow(new IOException()).when(sseEmitter).send(any(SseEmitter.SseEventBuilder.class));
 
         ArgumentCaptor<String> emitterIdCaptor = ArgumentCaptor.forClass(String.class);
 
@@ -140,9 +143,10 @@ class NotificationServiceTest {
             .willThrow(new RuntimeException("findAllEventCacheStartWithMemberId 실패"));
 
         //when
-        //then
         RuntimeException e = assertThrows(RuntimeException.class,
             () -> notificationService.subscribe(seller.getId(), lastEventId));
+
+        //then
         assertEquals("findAllEventCacheStartWithMemberId 실패", e.getMessage());
     }
 


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 알림 모달에서 특정 알림 선택시 관련 경매의 상세 페이지로 이동할 수 있도록 알림 전송 응답에 경매 pk값을 추가했습니다.

**TO-BE**


### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
- [x] API 테스트

### API 테스트 결과
#44 에서 auctionId가 포함된 응답을 확인 할 수 있습니다.