### PR TITLE
Fix/auction confirm twice(#62) - 구매 확정 2번 진행되는 경우 해결

### DIFF
--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -185,6 +185,15 @@ public class AuctionService {
             throw new IllegalStateException("진행 중인 경매에는 구매 확정을 할 수 없습니다.");
         }
 
+        Transaction transaction = transactionRepository.findByBuyerIdAndAuctionId(memberId,
+                auctionId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 거래내역입니다."));
+
+        // 이미 구매확정이 징행된 경우
+        if (transaction.getTransType().equals(TransType.SUCCESS)) {
+            throw new IllegalStateException("이미 종료된 거래입니다.");
+        }
+
         Member buyer = memberRepository.findByMemberId(memberId)
             .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
 

--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -389,7 +389,8 @@ public class AuctionService {
             .build();
         pointRepository.save(sellerPointHistory); // 판매자 포인트 히스토리 저장
 
-        Transaction buyerTransaction = transactionRepository.findByBuyerId(buyer.getId(),
+        Transaction buyerTransaction = transactionRepository.findByBuyerPkAndAuctionId(
+                buyer.getId(),
                 auction.getId())
             .orElseThrow(() -> new NoSuchElementException("존재하지 않는 거래 내역 입니다."));
 
@@ -398,7 +399,7 @@ public class AuctionService {
             .build();
         transactionRepository.save(buyerTransaction);
     }
-  
+
     // 즉시구매시 알림 전송
     private void sendNotificationForInstant(Auction auction, Member buyer) {
 

--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -206,7 +206,7 @@ public class AuctionService {
         memberRepository.save(seller);
 
         // 포인트 히스토리와 거래 내역 저장
-        savePointAndTransaction(confirmDto, buyer, seller, auction);
+        savePointAndTransaction(confirmDto, buyer, seller, transaction);
 
         // 판매자에게 구매 확정 알림보내기
         notificationService.send(confirmDto.getSellerId(), auctionId, "구매가 확정되었습니다.", CONFIRM);
@@ -380,7 +380,7 @@ public class AuctionService {
     // 포인트 히스토리와 거래 내역 저장 메소드
     private void savePointAndTransaction(AuctionConfirmDto.Request confirmDto, Member buyer,
         Member seller,
-        Auction auction) {
+        Transaction transaction) {
 
         PointHistory buyerPointHistory = PointHistory.builder()
             .curPointAmount(buyer.getPoint())
@@ -398,15 +398,10 @@ public class AuctionService {
             .build();
         pointRepository.save(sellerPointHistory); // 판매자 포인트 히스토리 저장
 
-        Transaction buyerTransaction = transactionRepository.findByBuyerPkAndAuctionId(
-                buyer.getId(),
-                auction.getId())
-            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 거래 내역 입니다."));
-
-        buyerTransaction = buyerTransaction.toBuilder()
+        transaction = transaction.toBuilder()
             .transType(TransType.SUCCESS)
             .build();
-        transactionRepository.save(buyerTransaction);
+        transactionRepository.save(transaction);
     }
 
     // 즉시구매시 알림 전송

--- a/src/main/java/com/ddang/usedauction/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/ddang/usedauction/transaction/repository/TransactionRepository.java
@@ -11,5 +11,5 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long>,
     TransactionRepositoryCustom {
 
     @Query("select t from Transaction t where t.buyer.id = :buyerId and t.auction.id = :auctionId")
-    Optional<Transaction> findByBuyerId(Long buyerId, Long auctionId); // 구매자 PK와 경매 PK로 거래 내역 조회
+    Optional<Transaction> findByBuyerPkAndAuctionId(Long buyerId, Long auctionId); // 구매자 PK와 경매 PK로 거래 내역 조회
 }

--- a/src/main/java/com/ddang/usedauction/transaction/repository/TransactionRepository.java
+++ b/src/main/java/com/ddang/usedauction/transaction/repository/TransactionRepository.java
@@ -11,5 +11,10 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long>,
     TransactionRepositoryCustom {
 
     @Query("select t from Transaction t where t.buyer.id = :buyerId and t.auction.id = :auctionId")
-    Optional<Transaction> findByBuyerPkAndAuctionId(Long buyerId, Long auctionId); // 구매자 PK와 경매 PK로 거래 내역 조회
+    Optional<Transaction> findByBuyerPkAndAuctionId(Long buyerId,
+        Long auctionId); // 구매자 PK와 경매 PK로 거래 내역 조회
+
+    @Query("select t from Transaction t where t.buyer.memberId = :buyerId and t.auction.id = :auctionId")
+    Optional<Transaction> findByBuyerIdAndAuctionId(String buyerId,
+        Long auctionId); // 구매자 아이디와 경매 pk로 거래 내역 조회
 }

--- a/src/test/java/com/ddang/usedauction/auction/service/AuctionServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/auction/service/AuctionServiceTest.java
@@ -449,7 +449,7 @@ class AuctionServiceTest {
         when(auctionRepository.findById(1L)).thenReturn(Optional.of(auction));
         when(memberRepository.findByMemberId("buyer")).thenReturn(Optional.of(buyer));
         when(memberRepository.findById(2L)).thenReturn(Optional.of(seller));
-        when(transactionRepository.findByBuyerPkAndAuctionId(1L, 1L)).thenReturn(
+        when(transactionRepository.findByBuyerIdAndAuctionId("buyer", 1L)).thenReturn(
             Optional.of(transaction));
 
         auctionService.confirmAuction(1L, "buyer", confirmDto);
@@ -479,7 +479,7 @@ class AuctionServiceTest {
     }
 
     @Test
-    @DisplayName("구매 확정 실패 - 없는 회원")
+    @DisplayName("구매 확정 실패 - 없는 거래 내역")
     void confirmAuctionFail2() {
 
         AuctionConfirmDto.Request confirmDto = AuctionConfirmDto.Request.builder()
@@ -494,6 +494,42 @@ class AuctionServiceTest {
             .build();
 
         when(auctionRepository.findById(1L)).thenReturn(Optional.of(auction));
+        when(transactionRepository.findByBuyerIdAndAuctionId("test", 1L)).thenReturn(
+            Optional.empty());
+
+        assertThrows(NoSuchElementException.class,
+            () -> auctionService.confirmAuction(1L, "test", confirmDto));
+    }
+
+    @Test
+    @DisplayName("구매 확정 실패 - 없는 회원")
+    void confirmAuctionFail3() {
+
+        AuctionConfirmDto.Request confirmDto = AuctionConfirmDto.Request.builder()
+            .price(1000)
+            .sellerId(2L)
+            .build();
+
+        Auction auction = Auction.builder()
+            .id(1L)
+            .title("title")
+            .auctionState(AuctionState.END)
+            .build();
+
+        Member buyer = Member.builder()
+            .id(1L)
+            .memberId("buyer")
+            .point(5000)
+            .build();
+
+        Transaction transaction = Transaction.builder()
+            .buyer(buyer)
+            .transType(TransType.CONTINUE)
+            .build();
+
+        when(auctionRepository.findById(1L)).thenReturn(Optional.of(auction));
+        when(transactionRepository.findByBuyerIdAndAuctionId("test", 1L)).thenReturn(
+            Optional.of(transaction));
         when(memberRepository.findByMemberId("test")).thenReturn(Optional.empty());
 
         assertThrows(NoSuchElementException.class,
@@ -502,7 +538,7 @@ class AuctionServiceTest {
 
     @Test
     @DisplayName("구매 확정 실패 - 진행중인 경매인 경우")
-    void confirmAuctionFail3() {
+    void confirmAuctionFail4() {
 
         AuctionConfirmDto.Request confirmDto = AuctionConfirmDto.Request.builder()
             .price(1000)
@@ -523,7 +559,7 @@ class AuctionServiceTest {
 
     @Test
     @DisplayName("구매 확정 실패 - 없는 거래 내역")
-    void confirmAuctionFail4() {
+    void confirmAuctionFail5() {
 
         AuctionConfirmDto.Request confirmDto = AuctionConfirmDto.Request.builder()
             .price(1000)
@@ -536,21 +572,9 @@ class AuctionServiceTest {
             .auctionState(AuctionState.END)
             .build();
 
-        Member buyer = Member.builder()
-            .id(1L)
-            .memberId("buyer")
-            .point(5000)
-            .build();
-
-        Member seller = Member.builder()
-            .memberId("seller")
-            .point(1000)
-            .build();
-
         when(auctionRepository.findById(1L)).thenReturn(Optional.of(auction));
-        when(memberRepository.findByMemberId("buyer")).thenReturn(Optional.of(buyer));
-        when(memberRepository.findById(2L)).thenReturn(Optional.of(seller));
-        when(transactionRepository.findByBuyerPkAndAuctionId(1L, 1L)).thenReturn(Optional.empty());
+        when(transactionRepository.findByBuyerIdAndAuctionId("buyer", 1L)).thenReturn(
+            Optional.empty());
 
         assertThrows(NoSuchElementException.class,
             () -> auctionService.confirmAuction(1L, "buyer", confirmDto));

--- a/src/test/java/com/ddang/usedauction/auction/service/AuctionServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/auction/service/AuctionServiceTest.java
@@ -449,7 +449,8 @@ class AuctionServiceTest {
         when(auctionRepository.findById(1L)).thenReturn(Optional.of(auction));
         when(memberRepository.findByMemberId("buyer")).thenReturn(Optional.of(buyer));
         when(memberRepository.findById(2L)).thenReturn(Optional.of(seller));
-        when(transactionRepository.findByBuyerId(1L, 1L)).thenReturn(Optional.of(transaction));
+        when(transactionRepository.findByBuyerPkAndAuctionId(1L, 1L)).thenReturn(
+            Optional.of(transaction));
 
         auctionService.confirmAuction(1L, "buyer", confirmDto);
 
@@ -549,7 +550,7 @@ class AuctionServiceTest {
         when(auctionRepository.findById(1L)).thenReturn(Optional.of(auction));
         when(memberRepository.findByMemberId("buyer")).thenReturn(Optional.of(buyer));
         when(memberRepository.findById(2L)).thenReturn(Optional.of(seller));
-        when(transactionRepository.findByBuyerId(1L, 1L)).thenReturn(Optional.empty());
+        when(transactionRepository.findByBuyerPkAndAuctionId(1L, 1L)).thenReturn(Optional.empty());
 
         assertThrows(NoSuchElementException.class,
             () -> auctionService.confirmAuction(1L, "buyer", confirmDto));

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceAutoConfirmTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceAutoConfirmTest.java
@@ -137,11 +137,12 @@ class NotificationServiceAutoConfirmTest {
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(memberRepository.findByMemberId(buyer.getMemberId())).willReturn(Optional.of(buyer));
         given(memberRepository.findById(seller.getId())).willReturn(Optional.of(seller));
-        given(transactionRepository.findByBuyerId(buyer.getId(), auction.getId()))
+        given(transactionRepository.findByBuyerPkAndAuctionId(buyer.getId(), auction.getId()))
             .willReturn(Optional.of(Transaction.builder().build()));
 
         ArgumentCaptor<Member> sellerCaptor = ArgumentCaptor.forClass(Member.class);
-        ArgumentCaptor<PointHistory> pointHistoryCaptor = ArgumentCaptor.forClass(PointHistory.class);
+        ArgumentCaptor<PointHistory> pointHistoryCaptor = ArgumentCaptor.forClass(
+            PointHistory.class);
         ArgumentCaptor<Transaction> transactionCaptor = ArgumentCaptor.forClass(Transaction.class);
 
         //when
@@ -208,7 +209,8 @@ class NotificationServiceAutoConfirmTest {
             .bidList(bidList)
             .build();
 
-        given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction_continue));
+        given(auctionRepository.findById(auction.getId())).willReturn(
+            Optional.of(auction_continue));
 
         //when
         assertThrows(IllegalStateException.class,
@@ -262,7 +264,7 @@ class NotificationServiceAutoConfirmTest {
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(memberRepository.findByMemberId(buyer.getMemberId())).willReturn(Optional.of(buyer));
         given(memberRepository.findById(confirmDto.getSellerId())).willReturn(Optional.of(seller));
-        given(transactionRepository.findByBuyerId(buyer.getId(), auction.getId()))
+        given(transactionRepository.findByBuyerPkAndAuctionId(buyer.getId(), auction.getId()))
             .willReturn(Optional.empty());
 
         //when

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
@@ -331,7 +331,7 @@ class NotificationServiceTest {
                 Notification.builder()
                     .id(2L)
                     .content("알림2")
-                    .notificationType(NotificationType.CHANGE_BID)
+                    .notificationType(NotificationType.CONFIRM)
                     .member(seller)
                     .build(),
                 Notification.builder()

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
@@ -113,7 +113,8 @@ class NotificationServiceTest {
 
         //when
         //then
-        assertThrows(RuntimeException.class, () -> notificationService.subscribe(seller.getId(), lastEventId));
+        assertThrows(RuntimeException.class,
+            () -> notificationService.subscribe(seller.getId(), lastEventId));
     }
 
     @Test
@@ -198,7 +199,8 @@ class NotificationServiceTest {
 
         //when
         NoSuchElementException e = assertThrows(NoSuchElementException.class,
-            () -> notificationService.send(seller.getId(), auction.getId(), content, notificationType));
+            () -> notificationService.send(seller.getId(), auction.getId(), content,
+                notificationType));
 
         //then
         assertEquals("존재하지 않는 회원입니다.", e.getMessage());
@@ -224,16 +226,19 @@ class NotificationServiceTest {
         given(memberRepository.findById(seller.getId())).willReturn(Optional.of(seller));
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(notificationRepository.save(any(Notification.class))).willReturn(notification);
-        given(emitterRepository.findAllEmitterStartWithMemberId(String.valueOf(seller.getId()))).willThrow(new RuntimeException("찾기 실패"));
+        given(emitterRepository.findAllEmitterStartWithMemberId(
+            String.valueOf(seller.getId()))).willThrow(new RuntimeException("찾기 실패"));
 
         //when
         RuntimeException e = assertThrows(RuntimeException.class,
-            () -> notificationService.send(seller.getId(), auction.getId(), content, notificationType));
+            () -> notificationService.send(seller.getId(), auction.getId(), content,
+                notificationType));
 
         //then
         assertEquals("찾기 실패", e.getMessage());
         verify(notificationRepository, times(1)).save(any(Notification.class));
-        verify(emitterRepository, times(1)).findAllEmitterStartWithMemberId(String.valueOf(seller.getId()));
+        verify(emitterRepository, times(1)).findAllEmitterStartWithMemberId(
+            String.valueOf(seller.getId()));
         verify(emitterRepository, times(0)).saveEventCache(anyString(), any(Notification.class));
     }
 
@@ -256,8 +261,10 @@ class NotificationServiceTest {
         given(memberRepository.findById(seller.getId())).willReturn(Optional.of(seller));
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(notificationRepository.save(any(Notification.class))).willReturn(notification);
-        given(emitterRepository.findAllEmitterStartWithMemberId(String.valueOf(seller.getId()))).willReturn(emitters);
-        doThrow(new RuntimeException("저장 실패")).when(emitterRepository).saveEventCache(anyString(), any(Notification.class));
+        given(emitterRepository.findAllEmitterStartWithMemberId(
+            String.valueOf(seller.getId()))).willReturn(emitters);
+        doThrow(new RuntimeException("저장 실패")).when(emitterRepository)
+            .saveEventCache(anyString(), any(Notification.class));
 
         //when
         assertThrows(RuntimeException.class, () -> {
@@ -338,19 +345,25 @@ class NotificationServiceTest {
         );
 
         given(memberRepository.findById(seller.getId())).willReturn(Optional.of(seller));
-        given(notificationRepository.findNotificationList(eq(seller.getId()), any(LocalDateTime.class), eq(pageable)))
+        given(notificationRepository.findNotificationList(eq(seller.getId()),
+            any(LocalDateTime.class), eq(pageable)))
             .willReturn(notificationPage);
 
         //when
-        Page<Notification> result = notificationService.getNotificationList(seller.getId(), pageable);
+        Page<Notification> result = notificationService.getNotificationList(seller.getId(),
+            pageable);
 
         //then
         assertEquals(notificationPage.getContent().size(), result.getTotalElements());
-        assertEquals(notificationPage.getContent().get(0).getContent(), result.getContent().get(0).getContent());
-        assertEquals(notificationPage.getContent().get(1).getContent(), result.getContent().get(1).getContent());
-        assertEquals(notificationPage.getContent().get(2).getContent(), result.getContent().get(2).getContent());
+        assertEquals(notificationPage.getContent().get(0).getContent(),
+            result.getContent().get(0).getContent());
+        assertEquals(notificationPage.getContent().get(1).getContent(),
+            result.getContent().get(1).getContent());
+        assertEquals(notificationPage.getContent().get(2).getContent(),
+            result.getContent().get(2).getContent());
 
-        verify(notificationRepository, times(1)).findNotificationList(eq(seller.getId()), any(LocalDateTime.class), eq(pageable));
+        verify(notificationRepository, times(1)).findNotificationList(eq(seller.getId()),
+            any(LocalDateTime.class), eq(pageable));
     }
 
     @Test
@@ -362,11 +375,13 @@ class NotificationServiceTest {
         given(memberRepository.findById(seller.getId())).willReturn(Optional.empty());
 
         //when
-        assertThrows(NoSuchElementException.class, () -> notificationService.getNotificationList(seller.getId(), pageable));
+        assertThrows(NoSuchElementException.class,
+            () -> notificationService.getNotificationList(seller.getId(), pageable));
 
         //then
         verify(memberRepository, times(1)).findById(seller.getId());
-        verify(notificationRepository, times(0)).findNotificationList(eq(seller.getId()), any(LocalDateTime.class), eq(pageable));
+        verify(notificationRepository, times(0)).findNotificationList(eq(seller.getId()),
+            any(LocalDateTime.class), eq(pageable));
     }
 
     @Test
@@ -383,10 +398,12 @@ class NotificationServiceTest {
         ArgumentCaptor<LocalDateTime> dateTimeCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
 
         //when
-        assertThrows(RuntimeException.class, () -> notificationService.getNotificationList(seller.getId(), pageable));
+        assertThrows(RuntimeException.class,
+            () -> notificationService.getNotificationList(seller.getId(), pageable));
 
         //then
         verify(memberRepository, times(1)).findById(seller.getId());
-        verify(notificationRepository, times(1)).findNotificationList(eq(seller.getId()), dateTimeCaptor.capture(), eq(pageable));
+        verify(notificationRepository, times(1)).findNotificationList(eq(seller.getId()),
+            dateTimeCaptor.capture(), eq(pageable));
     }
 }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 즉시 구매 시 구매자가 구매확정을 진행했음에도 자동구매확정이 한 번 더 진행되는 상황을 해결하였습니다.
- 거래 레포지토리에서 구매자 pk와 경매 pk를 통해 거래 엔티티 조회하는 메소드의 이름을 수정하였습니다.
- 거래 레포지토리에 구매자 아이이돠 경매 pk를 통해 거래 엔티티를 조회하는 메소드를 추가하였습니다.

**TO-BE**

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
- [x] API 테스트

### API 테스트

<details>
 <summary>즉시 구매 이후 구매 확정 진행</summary>

<img width="855" alt="image" src="https://github.com/user-attachments/assets/230bbbf0-4f97-455d-8d0b-07075a5c7019">

</details>

<details>
 <summary>이후 자동 구매 확정 진행 x</summary>

<img width="855" alt="image" src="https://github.com/user-attachments/assets/230bbbf0-4f97-455d-8d0b-07075a5c7019">

</details>