### PR TITLE
Fix/unauthorized(#70) -J WT 인증 및 권한 에러 핸들러 추가

### DIFF
--- a/src/main/java/com/ddang/usedauction/aop/LogAspect.java
+++ b/src/main/java/com/ddang/usedauction/aop/LogAspect.java
@@ -15,48 +15,49 @@ import org.springframework.stereotype.Component;
 @Component
 public class LogAspect {
 
-    // 모든 메소드 포인트컷
-    @Pointcut("execution(* com.ddang.usedauction..*(..)) "
-        + "&& !execution(* com.ddang.usedauction.config..*(..)) "
-        + "&& !execution(* com.ddang.usedauction.validation..*(..))"
-        + "&& !execution(* com.ddang.usedauction.util..*(..))")
-    public void all() {
-    }
+  // 모든 메소드 포인트컷
+  @Pointcut("execution(* com.ddang.usedauction..*(..)) "
+      + "&& !execution(* com.ddang.usedauction.config..*(..)) "
+      + "&& !execution(* com.ddang.usedauction.validation..*(..))"
+      + "&& !execution(* com.ddang.usedauction.util..*(..))"
+      + "&& !execution(* com.ddang.usedauction.security..*(..))")
+  public void all() {
+  }
 
-    // Controller클래스의 모든 메소드 포인트컷
-    @Pointcut("execution(* com.ddang.usedauction..*Controller.*(..))")
-    public void controller() {
-    }
+  // Controller클래스의 모든 메소드 포인트컷
+  @Pointcut("execution(* com.ddang.usedauction..*Controller.*(..))")
+  public void controller() {
+  }
 
-    // Service클래스의 모든 메소드 포인트컷
-    @Pointcut("execution(* com.ddang.usedauction..*Service.*(..))")
-    public void service() {
-    }
+  // Service클래스의 모든 메소드 포인트컷
+  @Pointcut("execution(* com.ddang.usedauction..*Service.*(..))")
+  public void service() {
+  }
 
-    // Service 또는 Controller의 메소드 실행 전 로그 표시
-    @Before("controller() || service()")
-    public void beforeLog(JoinPoint joinPoint) {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        Method method = signature.getMethod();
-        String className = joinPoint.getTarget().getClass().getSimpleName();
-        log.debug("[{}] {}메소드 실행", className, method.getName());
+  // Service 또는 Controller의 메소드 실행 전 로그 표시
+  @Before("controller() || service()")
+  public void beforeLog(JoinPoint joinPoint) {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    Method method = signature.getMethod();
+    String className = joinPoint.getTarget().getClass().getSimpleName();
+    log.debug("[{}] {}메소드 실행", className, method.getName());
 
-        Object[] args = joinPoint.getArgs();
-        for (Object arg : args) {
-            if (arg != null) {
-                log.debug("type = {}", arg.getClass().getSimpleName());
-                log.debug("value = {}", arg);
-            }
-        }
+    Object[] args = joinPoint.getArgs();
+    for (Object arg : args) {
+      if (arg != null) {
+        log.debug("type = {}", arg.getClass().getSimpleName());
+        log.debug("value = {}", arg);
+      }
     }
+  }
 
-    // 모든 메소드에서 예외 발생시 로그 표시
-    @AfterThrowing(pointcut = "all()", throwing = "ex")
-    public void afterThrowingLog(JoinPoint joinPoint, Throwable ex) {
-        MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
-        Method method = methodSignature.getMethod();
-        String className = joinPoint.getTarget().getClass().getSimpleName();
-        log.error("[{}] {}메소드에서 예외 발생", className, method.getName());
-        log.error("Exception message = {}", ex.getMessage());
-    }
+  // 모든 메소드에서 예외 발생시 로그 표시
+  @AfterThrowing(pointcut = "all()", throwing = "ex")
+  public void afterThrowingLog(JoinPoint joinPoint, Throwable ex) {
+    MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+    Method method = methodSignature.getMethod();
+    String className = joinPoint.getTarget().getClass().getSimpleName();
+    log.error("[{}] {}메소드에서 예외 발생", className, method.getName());
+    log.error("Exception message = {}", ex.getMessage());
+  }
 }

--- a/src/main/java/com/ddang/usedauction/config/SecurityConfig.java
+++ b/src/main/java/com/ddang/usedauction/config/SecurityConfig.java
@@ -6,11 +6,11 @@ import com.ddang.usedauction.security.jwt.JwtAuthenticationEntryPoint;
 import com.ddang.usedauction.security.jwt.JwtAuthenticationFilter;
 import com.ddang.usedauction.security.jwt.Oauth2FailureHandler;
 import com.ddang.usedauction.security.jwt.Oauth2SuccessHandler;
-import com.ddang.usedauction.security.jwt.TokenProvider;
-import com.ddang.usedauction.token.service.RefreshTokenService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -22,16 +22,15 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-  private final TokenProvider tokenProvider;
-  private final RefreshTokenService refreshTokenService;
+  private final ObjectMapper objectMapper;
   private final PrincipalOauth2UserService principalOauth2UserService;
   private final Oauth2SuccessHandler oauth2SuccessHandler;
   private final Oauth2FailureHandler oauth2FailureHandler;
-  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-  private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+  private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -47,6 +46,9 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth -> auth
             .anyRequest().permitAll()
         )
+        .exceptionHandling(exception -> exception
+            .authenticationEntryPoint(new JwtAuthenticationEntryPoint(objectMapper))
+            .accessDeniedHandler(new JwtAccessDeniedHandler(objectMapper)))
         .oauth2Login(oauth -> oauth// OAuth2 로그인 기능에 대한 여러 설정의 진입점
             // 로그인 성공 시 핸들러
             .successHandler(oauth2SuccessHandler)
@@ -55,13 +57,10 @@ public class SecurityConfig {
             // OAuth2 로그인 성공 이후 사용자 정보를 가져올 때의 설정을 담당
             .userInfoEndpoint(userInfo -> userInfo.userService(principalOauth2UserService))
         )
-        .addFilterBefore(new JwtAuthenticationFilter(tokenProvider, refreshTokenService),
-            UsernamePasswordAuthenticationFilter.class)
 
-        .exceptionHandling(exception -> exception
-            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-            .accessDeniedHandler(jwtAccessDeniedHandler));
-
+        .addFilterBefore(jwtAuthenticationFilter,
+            UsernamePasswordAuthenticationFilter.class);
     return http.build();
   }
+
 }

--- a/src/main/java/com/ddang/usedauction/config/SecurityConfig.java
+++ b/src/main/java/com/ddang/usedauction/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.ddang.usedauction.config;
 
 import com.ddang.usedauction.security.auth.PrincipalOauth2UserService;
+import com.ddang.usedauction.security.jwt.JwtAccessDeniedHandler;
+import com.ddang.usedauction.security.jwt.JwtAuthenticationEntryPoint;
 import com.ddang.usedauction.security.jwt.JwtAuthenticationFilter;
 import com.ddang.usedauction.security.jwt.Oauth2FailureHandler;
 import com.ddang.usedauction.security.jwt.Oauth2SuccessHandler;
@@ -28,6 +30,8 @@ public class SecurityConfig {
   private final PrincipalOauth2UserService principalOauth2UserService;
   private final Oauth2SuccessHandler oauth2SuccessHandler;
   private final Oauth2FailureHandler oauth2FailureHandler;
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+  private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -52,7 +56,12 @@ public class SecurityConfig {
             .userInfoEndpoint(userInfo -> userInfo.userService(principalOauth2UserService))
         )
         .addFilterBefore(new JwtAuthenticationFilter(tokenProvider, refreshTokenService),
-            UsernamePasswordAuthenticationFilter.class);
+            UsernamePasswordAuthenticationFilter.class)
+
+        .exceptionHandling(exception -> exception
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+            .accessDeniedHandler(jwtAccessDeniedHandler));
+
     return http.build();
   }
 }

--- a/src/main/java/com/ddang/usedauction/member/domain/enums/Role.java
+++ b/src/main/java/com/ddang/usedauction/member/domain/enums/Role.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum Role {
-  USER("일반 회원");
+  ROLE_USER("일반 회원");
   private String value;
 }

--- a/src/main/java/com/ddang/usedauction/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/ddang/usedauction/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,43 @@
+package com.ddang.usedauction.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final ObjectMapper objectMapper;
+
+  /**
+   * 403 에러 핸들링
+   */
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    response.setContentType("application/json;charset=utf-8");
+
+    setResponse(response);
+
+  }
+
+  /**
+   * Error 관련 응답 생성 메서드
+   */
+  private void setResponse(HttpServletResponse response) throws IOException {
+    String json = objectMapper.writeValueAsString(
+        Map.of(HttpStatus.FORBIDDEN, "권한이 없어서 요청이 거부되었습니다."));
+
+    response.getWriter().write(json);
+  }
+}

--- a/src/main/java/com/ddang/usedauction/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/ddang/usedauction/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.ddang.usedauction.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+  /**
+   * 401 에러 핸들링
+   */
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+    setResponse(response);
+  }
+
+  /**
+   * Error 관련 응답 생성 메서드
+   */
+  private void setResponse(HttpServletResponse response) throws IOException {
+
+    String json = objectMapper.writeValueAsString(Map.of(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."));
+
+    response.getWriter().write(json);
+  }
+}

--- a/src/main/java/com/ddang/usedauction/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ddang/usedauction/security/jwt/JwtAuthenticationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // accessToken 검증
     if (token != null && tokenProvider.validateToken(token)) {
       setAuthentication(token);
-    } else {
+    } else if (token != null && !tokenProvider.validateToken(token)) {
       // 만료되었으면 accessToken 재발급
       Authentication authentication = tokenProvider.getAuthentication(token);
       TokenDto dto = refreshTokenService.findTokenByEmail(authentication.getName());

--- a/src/main/java/com/ddang/usedauction/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ddang/usedauction/security/jwt/JwtAuthenticationFilter.java
@@ -12,10 +12,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
+@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Value("${spring.jwt.access.expiration}")
@@ -28,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       FilterChain filterChain) throws ServletException, IOException {
 
     String token = CookieUtil.getCookieValue(request, "JWT")
-        .orElseThrow(() -> new RuntimeException("쿠키가 존재하지 않습니다."));
+        .orElse(null);
     // accessToken 검증
     if (token != null && tokenProvider.validateToken(token)) {
       setAuthentication(token);

--- a/src/test/java/com/ddang/usedauction/member/servie/AuthServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/member/servie/AuthServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.ddang.usedauction.member.domain.entity.Member;
+import com.ddang.usedauction.member.domain.Member;
 import com.ddang.usedauction.member.domain.enums.Role;
 import com.ddang.usedauction.member.repository.MemberRepository;
 import com.ddang.usedauction.security.jwt.TokenProvider;
@@ -58,7 +58,7 @@ class AuthServiceTest {
   void setUp() {
     member = Member.builder()
         .email("test@gmail.com")
-        .role(Role.USER)
+        .role(Role.ROLE_USER)
         .build();
 
     tokenDto = TokenDto.builder()

--- a/src/test/java/com/ddang/usedauction/security/jwt/JwtExceptionHandlerTest.java
+++ b/src/test/java/com/ddang/usedauction/security/jwt/JwtExceptionHandlerTest.java
@@ -1,0 +1,83 @@
+package com.ddang.usedauction.security.jwt;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ddang.usedauction.config.SecurityConfig;
+import com.ddang.usedauction.member.controller.AuthController;
+import com.ddang.usedauction.member.servie.AuthService;
+import com.ddang.usedauction.security.auth.PrincipalOauth2UserService;
+import com.ddang.usedauction.token.service.RefreshTokenService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+@WebMvcTest({AuthController.class, SecurityConfig.class})
+class JwtExceptionHandlerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  WebApplicationContext context;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  TokenProvider tokenProvider;
+
+  @MockBean
+  RefreshTokenService refreshTokenService;
+
+  @MockBean
+  PrincipalOauth2UserService principalOauth2UserService;
+
+  @MockBean
+  Oauth2SuccessHandler oauth2SuccessHandler;
+
+  @MockBean
+  Oauth2FailureHandler oauth2FailureHandler;
+
+  @MockBean
+  AuthService authService;
+
+
+  @BeforeEach
+  void before() {
+    mockMvc = MockMvcBuilders
+        .webAppContextSetup(context)
+        .apply(springSecurity())
+        .build();
+  }
+
+  @Test
+  void Unauthorized() throws Exception {
+    mockMvc.perform(get("/api/auth/get")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.UNAUTHORIZED").value("로그인이 필요합니다."));
+  }
+
+  @Test
+  @WithMockUser(roles = "USER")
+  void accessDeniedHandler() throws Exception {
+    mockMvc.perform(get("/api/auth/get")
+            .with(csrf())
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.FORBIDDEN").value("권한이 없어서 요청이 거부되었습니다."));
+  }
+}


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 비회원이나 로그인한 회원의 권한으로 접근할 수 없는 API에 접근 시 예외처리를 추가하였습니다. (401, 403)
- JwtAuthenticationEntryPoint와 JwtAccessDeniedHandler를 구현하여
 인증 및 권한 관련 예외 발생 시 적절한 응답을 반환하도록 처리하였습니다.

**TO-BE**

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
- [x] API 테스트

<details>
<summary>비회원이 권한이 필요한 API 접근 시</summary>

<img width="830" alt="스크린샷 2024-08-21 오후 1 14 12" src="https://github.com/user-attachments/assets/e98ad3e5-4108-41b3-8622-cccac4c1a4c7">
<img width="758" alt="스크린샷 2024-08-21 오후 1 14 25" src="https://github.com/user-attachments/assets/c402d25d-f18a-445a-af83-d3d15a26d4ab">
</details>


<details>
<summary>권한을 갖지 못한 회원이 API 접근 시</summary>

![스크린샷 2024-08-21 오후 8 14 36](https://github.com/user-attachments/assets/f6d478b8-9083-4467-8f47-c5ef8c8ba974)
![스크린샷 2024-08-21 오후 8 14 23](https://github.com/user-attachments/assets/9157fa75-14c3-430a-a3e1-073d6f93a873)

</details>