### PR TITLE
Fix/get bid response - 회원의 입찰 목록 조회 시 응답 값 변경

### DIFF
--- a/src/main/java/com/ddang/usedauction/bid/dto/BidGetDto.java
+++ b/src/main/java/com/ddang/usedauction/bid/dto/BidGetDto.java
@@ -1,6 +1,9 @@
 package com.ddang.usedauction.bid.dto;
 
 import com.ddang.usedauction.bid.domain.Bid;
+import com.ddang.usedauction.image.domain.ImageType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,7 +22,10 @@ public class BidGetDto {
         private Long id;
         private long bidPrice; // 입찰가
         private Long auctionId; // 입찰한 경매 PK
+        private String thumbnailImageUrl; // 대표이미지 url
         private String memberId; // 입찰한 회원 id
+
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
         private LocalDateTime createdAt; // 생성 날짜
 
         // entity -> getResponse
@@ -29,6 +35,11 @@ public class BidGetDto {
                 .id(bid.getId())
                 .bidPrice(bid.getBidPrice())
                 .auctionId(bid.getAuction().getId())
+                .thumbnailImageUrl(
+                    bid.getAuction().getImageList().stream().filter(i -> i.getImageType().equals(
+                            ImageType.THUMBNAIL)).findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException("대표 이미지가 없습니다."))
+                        .getImageUrl())
                 .memberId(bid.getMember().getMemberId())
                 .createdAt(bid.getCreatedAt())
                 .build();

--- a/src/main/java/com/ddang/usedauction/bid/dto/BidGetDto.java
+++ b/src/main/java/com/ddang/usedauction/bid/dto/BidGetDto.java
@@ -22,6 +22,7 @@ public class BidGetDto {
         private Long id;
         private long bidPrice; // 입찰가
         private Long auctionId; // 입찰한 경매 PK
+        private String auctionTitle; // 경매 제목
         private String thumbnailImageUrl; // 대표이미지 url
         private String memberId; // 입찰한 회원 id
 
@@ -35,6 +36,7 @@ public class BidGetDto {
                 .id(bid.getId())
                 .bidPrice(bid.getBidPrice())
                 .auctionId(bid.getAuction().getId())
+                .auctionTitle(bid.getAuction().getTitle())
                 .thumbnailImageUrl(
                     bid.getAuction().getImageList().stream().filter(i -> i.getImageType().equals(
                             ImageType.THUMBNAIL)).findFirst()

--- a/src/test/java/com/ddang/usedauction/bid/controller/BidControllerTest.java
+++ b/src/test/java/com/ddang/usedauction/bid/controller/BidControllerTest.java
@@ -11,6 +11,8 @@ import com.ddang.usedauction.auction.domain.Auction;
 import com.ddang.usedauction.bid.domain.Bid;
 import com.ddang.usedauction.bid.service.BidService;
 import com.ddang.usedauction.config.SecurityConfig;
+import com.ddang.usedauction.image.domain.Image;
+import com.ddang.usedauction.image.domain.ImageType;
 import com.ddang.usedauction.member.domain.Member;
 import com.ddang.usedauction.security.auth.PrincipalOauth2UserService;
 import com.ddang.usedauction.security.jwt.Oauth2FailureHandler;
@@ -58,8 +60,14 @@ class BidControllerTest {
     @DisplayName("회원의 입찰 목록 조회 컨트롤러")
     void getBidListController() throws Exception {
 
+        Image image = Image.builder()
+            .imageType(ImageType.THUMBNAIL)
+            .imageUrl("url")
+            .build();
+
         Auction auction = Auction.builder()
             .id(1L)
+            .imageList(List.of(image))
             .build();
 
         Member member = Member.builder()


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 회원의 입찰 목록 조회 시 경매 제목과 경매의 대표 이미지, 입찰 날짜를 반환합니다.

**TO-BE**

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
- [x] API 테스트

### API 테스트

<details>
  <summary>회원의 입찰 목록 조회</summary>

<img width="879" alt="image" src="https://github.com/user-attachments/assets/0216271d-ed16-48e3-bfc3-1b18bea29d70">

```json
{
    "totalPages": 1,
    "totalElements": 1,
    "first": true,
    "last": true,
    "size": 10,
    "content": [
        {
            "id": 1,
            "bidPrice": 4000,
            "auctionId": 1,
            "auctionTitle": "test6",
            "thumbnailImageUrl": "https://movieticket-s3-bucket.s3.ap-northeast-2.amazonaws.com/99284810-4c33-4824-b78d-4fe3633677b2KakaoTalk_Photo_2024-08-13-19-13-19.jpeg",
            "memberId": "Google_b98b68",
            "createdAt": "2024-08-26 19:38"
        }
    ],
    "number": 0,
    "sort": {
        "empty": true,
        "unsorted": true,
        "sorted": false
    },
    "pageable": {
        "pageNumber": 0,
        "pageSize": 10,
        "sort": {
            "empty": true,
            "unsorted": true,
            "sorted": false
        },
        "offset": 0,
        "paged": true,
        "unpaged": false
    },
    "numberOfElements": 1,
    "empty": false
}
```

</details>