### PR TITLE
Feature/point history(#141) - 구매종료, 즉시구매시 포인트내역 저장

### DIFF
--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -411,6 +411,14 @@ public class AuctionService {
                 .build();
 
             memberRepository.save(member);
+
+            PointHistory pointHistory = PointHistory.builder()
+                .pointType(PointType.USE)
+                .pointAmount(bid.getBidPrice())
+                .curPointAmount(member.getPoint())
+                .member(member)
+                .build();
+            pointRepository.save(pointHistory);
         }
 
         Transaction transaction = Transaction.builder()

--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -317,6 +317,14 @@ public class AuctionService {
             .build();
         memberRepository.save(buyer);
 
+        PointHistory pointHistory = PointHistory.builder()
+            .pointType(PointType.USE)
+            .pointAmount(auction.getInstantPrice())
+            .curPointAmount(buyer.getPoint())
+            .member(buyer)
+            .build();
+        pointRepository.save(pointHistory);
+
         Transaction transaction = Transaction.builder()
             .price(auction.getInstantPrice())
             .transType(TransType.CONTINUE)

--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -455,14 +455,6 @@ public class AuctionService {
         Member seller,
         Transaction transaction) {
 
-        PointHistory buyerPointHistory = PointHistory.builder()
-            .curPointAmount(buyer.getPoint())
-            .pointType(PointType.USE)
-            .pointAmount(confirmDto.getPrice())
-            .member(buyer)
-            .build();
-        pointRepository.save(buyerPointHistory); // 구매자 포인트 히스토리 저장
-
         PointHistory sellerPointHistory = PointHistory.builder()
             .curPointAmount(seller.getPoint())
             .pointType(PointType.GET)

--- a/src/test/java/com/ddang/usedauction/auction/service/AuctionServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/auction/service/AuctionServiceTest.java
@@ -543,8 +543,6 @@ class AuctionServiceTest {
 
         verify(memberRepository, times(1)).save(argThat(arg -> arg.getPoint() == 2000));
         verify(pointRepository, times(1)).save(
-            argThat(arg -> arg.getPointType().equals(PointType.USE)));
-        verify(pointRepository, times(1)).save(
             argThat(arg -> arg.getPointType().equals(PointType.GET)));
         verify(transactionRepository, times(1)).save(
             argThat(arg -> arg.getTransType().equals(TransType.SUCCESS)));

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceAutoConfirmTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceAutoConfirmTest.java
@@ -33,7 +33,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@Disabled
 class NotificationServiceAutoConfirmTest {
 
     @Mock
@@ -114,7 +113,7 @@ class NotificationServiceAutoConfirmTest {
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(transactionRepository.findByBuyerIdAndAuctionId(buyer.getMemberId(), auction.getId()))
             .willReturn(Optional.of(buyerTransaction));
-        given(memberRepository.findByEmail(buyer.getEmail())).willReturn(Optional.of(buyer));
+        given(memberRepository.findByMemberId(buyer.getMemberId())).willReturn(Optional.of(buyer));
         given(memberRepository.findById(seller.getId())).willReturn(Optional.of(seller));
 
         //when
@@ -213,7 +212,7 @@ class NotificationServiceAutoConfirmTest {
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(transactionRepository.findByBuyerIdAndAuctionId(buyer.getMemberId(), auction.getId()))
             .willReturn(Optional.of(buyerTransaction));
-        given(memberRepository.findByEmail(buyer.getEmail())).willReturn(Optional.empty());
+        given(memberRepository.findByMemberId(buyer.getMemberId())).willReturn(Optional.empty());
 
         //when
         assertThrows(NoSuchElementException.class,
@@ -245,7 +244,7 @@ class NotificationServiceAutoConfirmTest {
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(transactionRepository.findByBuyerIdAndAuctionId(buyer.getMemberId(), auction.getId()))
             .willReturn(Optional.of(buyerTransaction));
-        given(memberRepository.findByEmail(buyer.getEmail())).willReturn(Optional.of(buyer));
+        given(memberRepository.findByMemberId(buyer.getMemberId())).willReturn(Optional.of(buyer));
         given(memberRepository.findById(confirmDto.getSellerId())).willReturn(Optional.empty());
 
         //when

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceInstantPurchaseTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceInstantPurchaseTest.java
@@ -4,6 +4,7 @@ import static com.ddang.usedauction.auction.domain.AuctionState.CONTINUE;
 import static com.ddang.usedauction.auction.domain.AuctionState.END;
 import static com.ddang.usedauction.notification.domain.NotificationType.DONE_INSTANT;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -16,6 +17,9 @@ import com.ddang.usedauction.auction.service.AuctionService;
 import com.ddang.usedauction.chat.service.ChatRoomService;
 import com.ddang.usedauction.member.domain.Member;
 import com.ddang.usedauction.member.repository.MemberRepository;
+import com.ddang.usedauction.point.domain.PointHistory;
+import com.ddang.usedauction.point.domain.PointType;
+import com.ddang.usedauction.point.repository.PointRepository;
 import com.ddang.usedauction.transaction.repository.TransactionRepository;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -47,6 +51,9 @@ class NotificationServiceInstantPurchaseTest {
     @Mock
     private ChatRoomService chatRoomService;
 
+    @Mock
+    private PointRepository pointRepository;
+
     @InjectMocks
     private AuctionService auctionService;
 
@@ -71,8 +78,11 @@ class NotificationServiceInstantPurchaseTest {
             .seller(seller)
             .build();
 
+        PointHistory pointHistory = PointHistory.builder().build();
+
         given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
         given(memberRepository.findByMemberId(buyer.getMemberId())).willReturn(Optional.of(buyer));
+        given(pointRepository.save(argThat(arg -> arg.getPointType().equals(PointType.USE)))).willReturn(pointHistory);
 
         //when
         auctionService.instantPurchaseAuction(auction.getId(), buyer.getMemberId());


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 경매종료시 낙찰자의 포인트 감소 내역을 저장합니다.
- 즉시구매시 낙찰자의 포인트 감소 내역을 저장합니다.

**TO-BE**

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
- [x] API 테스트

### API 테스트 결과
<details>
<summary>경매 종료시</summary>

입찰하기
<img width="679" alt="스크린샷 2024-08-31 11 12 17" src="https://github.com/user-attachments/assets/e78f1980-9156-4402-b0dc-83f2fe9007c7">

경매종료 후 포인트 내역 확인
<img width="789" alt="스크린샷 2024-08-31 11 12 30" src="https://github.com/user-attachments/assets/852dbd63-cbfb-417f-8eb6-37eea5160b0b">

구매확정시 판매자 포인트 증가
<img width="802" alt="스크린샷 2024-08-31 11 13 32" src="https://github.com/user-attachments/assets/9671b3bc-d4f3-4373-b30a-58ad7ee292a8">


</details>

<details>
<summary>즉시 구매시</summary>

즉시구매하기
<img width="1002" alt="스크린샷 2024-08-31 11 19 04" src="https://github.com/user-attachments/assets/472ab3f5-4297-447a-9447-d18bac9877cd">

즉시구매후 포인트 내역
<img width="782" alt="스크린샷 2024-08-31 11 19 22" src="https://github.com/user-attachments/assets/50463a08-a49e-479a-a624-80c07a6ce548">

구매확정시 판매자 포인트 증가
<img width="774" alt="스크린샷 2024-08-31 11 19 41" src="https://github.com/user-attachments/assets/f6fdd61e-5bb5-4215-a6f7-9cc20531820c">

</details>