### PR TITLE
Fix/notification delete paging - 알림전체조회시 페이징 기능 제거

### DIFF
--- a/src/main/java/com/ddang/usedauction/notification/controller/NotificationController.java
+++ b/src/main/java/com/ddang/usedauction/notification/controller/NotificationController.java
@@ -5,6 +5,7 @@ import com.ddang.usedauction.notification.dto.NotificationDto;
 import com.ddang.usedauction.notification.dto.NotificationDto.Response;
 import com.ddang.usedauction.notification.service.NotificationService;
 import com.ddang.usedauction.security.auth.PrincipalDetails;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,18 +46,15 @@ public class NotificationController {
     /**
      * 알림 전체 목록 조회
      *
-     * @param pageable page, size
      * @return 성공 시 200 코드와 알림 전체 목록, 실패 시 에러메시지
      */
     @PreAuthorize("hasRole('USER')")
     @GetMapping
-    public ResponseEntity<Page<NotificationDto.Response>> getNotificationList(
-        @AuthenticationPrincipal PrincipalDetails principalDetails,
-        @PageableDefault Pageable pageable
+    public ResponseEntity<List<NotificationDto.Response>> getNotificationList(
+        @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
         String memberId = principalDetails.getName();
-        Page<Notification> notificationPage = notificationService.getNotificationList(memberId,
-            pageable);
-        return ResponseEntity.ok(notificationPage.map(Response::from));
+        List<Notification> notifications = notificationService.getNotificationList(memberId);
+        return ResponseEntity.ok(notifications.stream().map(Response::from).toList());
     }
 }

--- a/src/main/java/com/ddang/usedauction/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ddang/usedauction/notification/repository/NotificationRepository.java
@@ -2,8 +2,7 @@ package com.ddang.usedauction.notification.repository;
 
 import com.ddang.usedauction.notification.domain.Notification;
 import java.time.LocalDateTime;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,8 +15,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
         + "where n.member.memberId = :memberId "
         + "and n.createdAt >= :beforeOneMonth "
         + "order by n.createdAt desc")
-    Page<Notification> findNotificationList(
+    List<Notification> findNotificationList(
         @Param("memberId") String memberId,
-        @Param("beforeOneMonth") LocalDateTime beforeOneMonth,
-        Pageable pageable);
+        @Param("beforeOneMonth") LocalDateTime beforeOneMonth);
 }

--- a/src/main/java/com/ddang/usedauction/notification/service/NotificationService.java
+++ b/src/main/java/com/ddang/usedauction/notification/service/NotificationService.java
@@ -11,6 +11,7 @@ import com.ddang.usedauction.notification.repository.EmitterRepository;
 import com.ddang.usedauction.notification.repository.NotificationRepository;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -88,14 +89,14 @@ public class NotificationService {
 
     // 알림 전체 목록 조회
     @Transactional(readOnly = true)
-    public Page<Notification> getNotificationList(String memberId, Pageable pageable) {
+    public List<Notification> getNotificationList(String memberId) {
 
         memberRepository.findByMemberId(memberId)
             .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
 
         LocalDateTime beforeOneMonth = LocalDateTime.now().minusMonths(1);
 
-        return notificationRepository.findNotificationList(memberId, beforeOneMonth, pageable);
+        return notificationRepository.findNotificationList(memberId, beforeOneMonth);
     }
 
     // 실제로 알림을 전송하는 메서드

--- a/src/test/java/com/ddang/usedauction/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/controller/NotificationControllerTest.java
@@ -109,9 +109,7 @@ class NotificationControllerTest {
             .email("test@naver.com")
             .build();
 
-        Pageable pageable = PageRequest.of(0, 10);
-
-        Page<Notification> notificationPage = new PageImpl<>(
+        List<Notification> notifications =
             List.of(
                 Notification.builder()
                     .id(1L)
@@ -130,13 +128,10 @@ class NotificationControllerTest {
                     .content("알림3")
                     .notificationType(NotificationType.QUESTION)
                     .member(member)
-                    .build()),
-            pageable,
-            3
-        );
+                    .build());
 
-        given(notificationService.getNotificationList(member.getMemberId(), pageable))
-            .willReturn(notificationPage);
+        given(notificationService.getNotificationList(member.getMemberId()))
+            .willReturn(notifications);
 
         //when
         //then
@@ -145,10 +140,10 @@ class NotificationControllerTest {
                     .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.content[0].content").value("알림1"))
-            .andExpect(jsonPath("$.content[1].content").value("알림2"))
-            .andExpect(jsonPath("$.content[2].content").value("알림3"))
-            .andExpect(jsonPath("$.content.size()").value(3));
+            .andExpect(jsonPath("$.[0].content").value("알림1"))
+            .andExpect(jsonPath("$.[1].content").value("알림2"))
+            .andExpect(jsonPath("$.[2].content").value("알림3"))
+            .andExpect(jsonPath("$.length()").value(3));
     }
 
     @Test

--- a/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/ddang/usedauction/notification/service/NotificationServiceTest.java
@@ -390,7 +390,7 @@ class NotificationServiceTest {
         //given
         Pageable pageable = PageRequest.of(0, 10);
 
-        Page<Notification> notificationPage = new PageImpl<>(
+        List<Notification> notifications =
             List.of(
                 Notification.builder()
                     .id(1L)
@@ -409,32 +409,29 @@ class NotificationServiceTest {
                     .content("알림3")
                     .notificationType(NotificationType.QUESTION)
                     .member(member)
-                    .build()),
-            pageable,
-            3
-        );
+                    .build());
 
         given(memberRepository.findByMemberId(member.getMemberId())).willReturn(
             Optional.of(member));
         given(notificationRepository.findNotificationList(
-            eq(member.getMemberId()), any(LocalDateTime.class), eq(pageable))
-        ).willReturn(notificationPage);
+            eq(member.getMemberId()), any(LocalDateTime.class))
+        ).willReturn(notifications);
 
         //when
-        Page<Notification> result = notificationService.getNotificationList(
-            member.getMemberId(), pageable);
+        List<Notification> result = notificationService.getNotificationList(
+            member.getMemberId());
 
         //then
-        assertEquals(notificationPage.getContent().size(), result.getTotalElements());
-        assertEquals(notificationPage.getContent().get(0).getContent(),
-            result.getContent().get(0).getContent());
-        assertEquals(notificationPage.getContent().get(1).getContent(),
-            result.getContent().get(1).getContent());
-        assertEquals(notificationPage.getContent().get(2).getContent(),
-            result.getContent().get(2).getContent());
+        assertEquals(notifications.size(), result.size());
+        assertEquals(notifications.get(0).getContent(),
+            result.get(0).getContent());
+        assertEquals(notifications.get(1).getContent(),
+            result.get(1).getContent());
+        assertEquals(notifications.get(2).getContent(),
+            result.get(2).getContent());
 
         verify(notificationRepository, times(1)).findNotificationList(
-            eq(member.getMemberId()), any(LocalDateTime.class), eq(pageable));
+            eq(member.getMemberId()), any(LocalDateTime.class));
     }
 
     @Test
@@ -449,12 +446,12 @@ class NotificationServiceTest {
 
         //when
         assertThrows(NoSuchElementException.class,
-            () -> notificationService.getNotificationList(member.getMemberId(), pageable));
+            () -> notificationService.getNotificationList(member.getMemberId()));
 
         //then
         verify(memberRepository, times(1)).findByMemberId(member.getMemberId());
         verify(notificationRepository, times(0)).findNotificationList(
-            eq(member.getMemberId()), dateTimeCaptor.capture(), eq(pageable));
+            eq(member.getMemberId()), dateTimeCaptor.capture());
     }
 
     @Test
@@ -466,19 +463,18 @@ class NotificationServiceTest {
 
         given(memberRepository.findByMemberId(member.getMemberId())).willReturn(
             Optional.of(member));
-        given(notificationRepository.findNotificationList(member.getMemberId(), beforeOneMonth,
-            pageable))
+        given(notificationRepository.findNotificationList(member.getMemberId(), beforeOneMonth))
             .willThrow(new RuntimeException());
 
         ArgumentCaptor<LocalDateTime> dateTimeCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
 
         //when
         assertThrows(RuntimeException.class,
-            () -> notificationService.getNotificationList(member.getMemberId(), pageable));
+            () -> notificationService.getNotificationList(member.getMemberId()));
 
         //then
         verify(memberRepository, times(1)).findByMemberId(member.getMemberId());
         verify(notificationRepository, times(1)).findNotificationList(
-            eq(member.getMemberId()), dateTimeCaptor.capture(), eq(pageable));
+            eq(member.getMemberId()), dateTimeCaptor.capture());
     }
 }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 알림전체조회시 페이징 기능이 필요없어서 제거했습니다.

**TO-BE**

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [x] 테스트 코드
- [x] API 테스트

### API 테스트 결과
<details>
<summary>전체 알림 조회</summary>

1달 이전의 알림 데이터들도 저장
<img width="703" alt="스크린샷 2024-08-31 17 49 24" src="https://github.com/user-attachments/assets/8888b753-7c58-44c6-bb64-b60ef5759006">

알림 내역 조회
<img width="1000" alt="스크린샷 2024-08-31 17 49 39" src="https://github.com/user-attachments/assets/e12d87da-0273-4fc4-a84a-bc68d0a3d2c5">

```
[
    {
        "id": 8,
        "memberId": 1,
        "auctionId": 1,
        "content": "알림8",
        "notificationType": "DONE",
        "createdAt": "2024-08-17T10:00:00"
    },
    {
        "id": 7,
        "memberId": 1,
        "auctionId": 1,
        "content": "알림7",
        "notificationType": "DONE",
        "createdAt": "2024-08-16T10:00:00"
    },
    {
        "id": 6,
        "memberId": 1,
        "auctionId": 1,
        "content": "알림6",
        "notificationType": "DONE",
        "createdAt": "2024-08-10T10:00:00"
    }
]
```
</details>