### PR TITLE
Feature/exit chat room(#150) - 즉시 구매시 채팅방, 채팅 메시지 삭제

### DIFF
--- a/src/main/java/com/ddang/usedauction/auction/listener/AuctionEventListener.java
+++ b/src/main/java/com/ddang/usedauction/auction/listener/AuctionEventListener.java
@@ -10,6 +10,8 @@ import com.ddang.usedauction.auction.event.AuctionEndEvent;
 import com.ddang.usedauction.auction.repository.AuctionRepository;
 import com.ddang.usedauction.auction.service.AuctionRedisService;
 import com.ddang.usedauction.auction.service.AuctionService;
+import com.ddang.usedauction.chat.domain.entity.ChatRoom;
+import com.ddang.usedauction.chat.service.ChatMessageService;
 import com.ddang.usedauction.chat.service.ChatRoomService;
 import com.ddang.usedauction.member.domain.Member;
 import com.ddang.usedauction.member.repository.MemberRepository;
@@ -36,6 +38,7 @@ public class AuctionEventListener { // 경매 이벤트 리스너
     private final NotificationService notificationService;
     private final AuctionRepository auctionRepository;
     private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
 
     // 경매 종료 이벤트 리스너
     @EventListener
@@ -88,6 +91,9 @@ public class AuctionEventListener { // 경매 이벤트 리스너
         }
 
         auctionService.confirmAuction(auctionId, buyerId, confirmDto);
+
+        ChatRoom chatRoom = chatRoomService.deleteChatRoom(auctionId);
+        chatMessageService.deleteMessagesByChatRoom(chatRoom.getId());
     }
 
     // 경매 종료 알림 전송

--- a/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
+++ b/src/main/java/com/ddang/usedauction/auction/service/AuctionService.java
@@ -21,6 +21,8 @@ import com.ddang.usedauction.auction.repository.AuctionRepository;
 import com.ddang.usedauction.bid.domain.Bid;
 import com.ddang.usedauction.category.domain.Category;
 import com.ddang.usedauction.category.repository.CategoryRepository;
+import com.ddang.usedauction.chat.domain.entity.ChatRoom;
+import com.ddang.usedauction.chat.service.ChatMessageService;
 import com.ddang.usedauction.chat.service.ChatRoomService;
 import com.ddang.usedauction.image.domain.Image;
 import com.ddang.usedauction.image.service.ImageService;
@@ -68,6 +70,7 @@ public class AuctionService {
     private final RedisTemplate<String, AuctionRecentDto> redisTemplate;
 
     private static final String RECENTLY_AUCTION_LIST_REDIS_KEY_PREFIX = "recently::";
+    private final ChatMessageService chatMessageService;
 
     /**
      * 경매글 단건 조회
@@ -258,6 +261,9 @@ public class AuctionService {
 
         // 구매 확정 알림 전송
         sendNotificationForConfirm(buyer, auction);
+
+        ChatRoom chatRoom = chatRoomService.deleteChatRoom(auctionId);
+        chatMessageService.deleteMessagesByChatRoom(chatRoom.getId());
     }
 
     /**

--- a/src/main/java/com/ddang/usedauction/chat/domain/entity/ChatMessage.java
+++ b/src/main/java/com/ddang/usedauction/chat/domain/entity/ChatMessage.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,4 +39,6 @@ public class ChatMessage extends BaseTimeEntity {
     @JoinColumn(name = "chatRoom_id")
     private ChatRoom chatRoom;
 
+    @Column
+    private LocalDateTime deletedAt; // 삭제 날짜
 }

--- a/src/main/java/com/ddang/usedauction/chat/domain/entity/ChatRoom.java
+++ b/src/main/java/com/ddang/usedauction/chat/domain/entity/ChatRoom.java
@@ -47,5 +47,8 @@ public class ChatRoom extends BaseTimeEntity implements Serializable {
     @Column
     private LocalDateTime deletedAt; // 삭제 날짜
 
+    public void exitChatRoom() {
+        this.deletedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/ddang/usedauction/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ddang/usedauction/chat/repository/ChatMessageRepository.java
@@ -3,8 +3,15 @@ package com.ddang.usedauction.chat.repository;
 import com.ddang.usedauction.chat.domain.entity.ChatMessage;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
     List<ChatMessage> findByChatRoomIdOrderByCreatedAtAsc(Long chatRomeId);
+
+    @Modifying
+    @Query("UPDATE ChatMessage m SET m.deletedAt = CURRENT_TIMESTAMP WHERE  m.chatRoom.id = :chatRoomId")
+    void deleteChatMessageByChatRoomId(@Param("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/ddang/usedauction/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/ddang/usedauction/chat/repository/ChatRoomRepository.java
@@ -1,9 +1,12 @@
 package com.ddang.usedauction.chat.repository;
 
 import com.ddang.usedauction.chat.domain.entity.ChatRoom;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-  boolean existsByAuctionId(Long auctionId);
+    Optional<ChatRoom> findByAuctionId(Long auctionId);
+
+    boolean existsByAuctionId(Long auctionId);
 }

--- a/src/main/java/com/ddang/usedauction/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ddang/usedauction/chat/service/ChatMessageService.java
@@ -64,6 +64,12 @@ public class ChatMessageService {
             .collect(Collectors.toList());
     }
 
+    @Transactional
+    public void deleteMessagesByChatRoom(Long chatRoomId) {
+        chatMessageRepository.deleteChatMessageByChatRoomId(chatRoomId);
+    }
+
+
     private boolean isMemberOfChatRoom(ChatRoom chatRoom, String memberId) {
         return chatRoom.getSeller().getMemberId().equals(memberId) ||
             chatRoom.getBuyer().getMemberId().equals(memberId);

--- a/src/main/java/com/ddang/usedauction/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ddang/usedauction/chat/service/ChatRoomService.java
@@ -80,6 +80,20 @@ public class ChatRoomService {
         createTopic(chatRoom.getId().toString());
     }
 
+    public ChatRoom deleteChatRoom(Long auctionId) {
+
+        ChatRoom chatRoom = chatRoomRepository.findByAuctionId(auctionId)
+            .orElseThrow(() -> new NoSuchElementException("존재하지 않는 채팅방입니다"));
+
+        opsHashChatRoom.delete(CHAT_ROOMS, chatRoom.getId().toString());
+
+        chatRoom.exitChatRoom();
+
+        deleteTopic(chatRoom.getId().toString());
+
+        return chatRoom;
+    }
+
     public ChannelTopic getTopic(Long roomId) {
         return topics.get(roomId.toString());
     }
@@ -90,5 +104,12 @@ public class ChatRoomService {
             redisMessageListener.addMessageListener(redisSubscriber, topic);
             topics.put(roomId, topic);
         }
+    }
+
+    private void deleteTopic(String roomId) {
+        ChannelTopic topic = topics.get(roomId);
+
+        redisMessageListener.removeMessageListener(redisSubscriber, topic);
+        topics.remove(roomId);
     }
 }


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 즉시 구매가 되면 해당 채팅방을 조회하여 삭제 날짜가 업데이트 됩니다.
- 채팅방의 ID로 채팅 메시지가 JPA 벌크 연산으로 삭제 날짜가 업데이트 됩니다.

**TO-BE**

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트

<details>
<summary> 채팅방 및 메시지 삭제</summary>

![스크린샷 2024-09-01 오전 2 36 49](https://github.com/user-attachments/assets/8124794a-e1f8-4ce7-867c-4891cf078247)
![스크린샷 2024-09-01 오전 2 37 15](https://github.com/user-attachments/assets/6f282331-4bd6-4d0d-aaf4-1dd5190d2638)
![스크린샷 2024-09-01 오전 2 37 06](https://github.com/user-attachments/assets/9bedb30b-9c41-4feb-88e6-3d393b9716fd)


</details>
