### PR TITLE
Feature/remove redis data chat - 구매 확정 시 채팅방 삭제 될 때 읽지 않은 메시지, 채팅방 입장 redis 데이터 삭제

### DIFF
--- a/src/main/java/com/ddang/usedauction/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ddang/usedauction/chat/service/ChatMessageService.java
@@ -54,7 +54,7 @@ public class ChatMessageService {
             ? chatRoom.getBuyer().getMemberId() : chatRoom.getSeller().getMemberId();
 
         if (!redisTemplate.opsForSet().isMember(
-            "CHAT_ROOM" + chatRoom.getId() + "_MEMBERS:", receiverId)) {
+            "CHAT_ROOM" + chatRoom.getId() + "_MEMBERS", receiverId)) {
             String unreadKey = "CHAT_ROOM" + chatRoom.getId() + "_UN_READ:" + receiverId;
             unReadTemplate.opsForValue().increment(unreadKey, 1);
         }

--- a/src/main/java/com/ddang/usedauction/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ddang/usedauction/chat/service/ChatRoomService.java
@@ -116,7 +116,7 @@ public class ChatRoomService {
      * 채팅방 입장
      */
     public void enterChatRoom(Long roomId, String memberId) {
-        redisTemplate.opsForSet().add("CHAT_ROOM" + roomId + "_MEMBERS:", memberId);
+        redisTemplate.opsForSet().add("CHAT_ROOM" + roomId + "_MEMBERS", memberId);
 
     }
 
@@ -125,7 +125,7 @@ public class ChatRoomService {
      */
     public void exitChatRoom(Long roomId, String memberId) {
         redisTemplate.opsForSet()
-            .remove("CHAT_ROOM" + roomId + "_MEMBERS:", memberId);
+            .remove("CHAT_ROOM" + roomId + "_MEMBERS", memberId);
     }
 
     /**


### PR DESCRIPTION
### 변경사항

<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 채팅방 삭제 메서드 실행시 읽지 않은 메시지, 채팅방 입장 redis 데이터가 삭제됩니다.

- 읽지 않은 메시지, 채팅방 입장 삭제되는 로직
1.삭제할 키들의 접두사를 정의
2.접두사로 시작하는 모든 키 검색 (채팅방 별로 한번에 3개의 키 검색 - unReadCnt 판매자 구매자 따로, 채팅방 입장 set 형태)
3.키 수집
4.키 String으로 변환 후 삭제


**TO-BE**

### 테스트

<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 

- [ ] 테스트 코드
- [x] API 테스트

<details>
<summary> 채팅방 및 메시지 삭제</summary>

![스크린샷 2024-09-03 오후 6 26 06](https://github.com/user-attachments/assets/1938f7c3-517e-44ee-88cc-9240373bee1a)
</details>